### PR TITLE
Fix a problem reading configuration in mixed casing

### DIFF
--- a/Gigya.Microdot.Configuration/ConfigCache.cs
+++ b/Gigya.Microdot.Configuration/ConfigCache.cs
@@ -70,7 +70,7 @@ namespace Gigya.Microdot.Configuration
             path = path + ".";
             var root = new JObject();
 
-            foreach (var configItem in LatestConfig.Items.Where(kvp => kvp.Key.StartsWith(path)))
+            foreach (var configItem in LatestConfig.Items.Where(kvp => kvp.Key.StartsWith(path,StringComparison.OrdinalIgnoreCase)))
             {
                 var pathParts = configItem.Key.Substring(path.Length).Split('.');
                 var currentObj = root;

--- a/Gigya.Microdot.UnitTests/Configuration/BusSettings.cs
+++ b/Gigya.Microdot.UnitTests/Configuration/BusSettings.cs
@@ -78,12 +78,20 @@ namespace Gigya.Microdot.UnitTests.Configuration
         public string Name { get; set; }
     }
 
+   
     [ConfigurationRoot("Prefix1.Prefix2", RootStrategy.AppendClassNameToPath)]
     public class GatorConfig : IConfigObject
     {
         public string Name { get; set; } = "Default";
     }
 
+    [ConfigurationRoot("Prefix1.Prefix2.gatorConfig", RootStrategy.ReplaceClassNameWithPath)]
+    public class GatorLowerCase : IConfigObject
+    {
+        public string Name { get; set; }
+
+        public NotConfigObject NotConfigObject { get; set; }
+    }
 
 
     [ConfigurationRoot("Prefix1.Prefix2.GatorConfig", RootStrategy.ReplaceClassNameWithPath)]

--- a/Gigya.Microdot.UnitTests/Configuration/TypedConfigTest.cs
+++ b/Gigya.Microdot.UnitTests/Configuration/TypedConfigTest.cs
@@ -300,6 +300,7 @@ namespace Gigya.Microdot.UnitTests.Configuration
             infraKernel.Dispose();
         }
 
+
         [Test]
         public void AllPropertiesExceptNullableShouldBeSet()
         {
@@ -352,6 +353,22 @@ namespace Gigya.Microdot.UnitTests.Configuration
                 {"Prefix1.Prefix2.GatorConfig.Name", "infraTest"},
             });
             var extractor = infraKernel.Get<Func<GatorConfig>>();
+
+            var busSettings = extractor();
+            busSettings.ShouldNotBeNull();
+            busSettings.Name.ShouldBe("infraTest");
+
+            infraKernel.Dispose();
+        }
+
+        [Test]
+        public void CanReadWithReplacingPrefixWInWrongCase()
+        {
+            var infraKernel = new TestingKernel<ConsoleLog>(mockConfig: new Dictionary<string, string>
+            {
+                {"Prefix1.Prefix2.GatorConfig.Name", "infraTest"},
+            });
+            var extractor = infraKernel.Get<Func<GatorLowerCase>>();
 
             var busSettings = extractor();
             busSettings.ShouldNotBeNull();


### PR DESCRIPTION
Saw a problem when ConfigurationRootAttribute was used with casing different from configuration