### PR TITLE
Initialize Metrics.NET when application starts

### DIFF
--- a/Gigya.Microdot.Fakes/Gigya.Microdot.Fakes.csproj
+++ b/Gigya.Microdot.Fakes/Gigya.Microdot.Fakes.csproj
@@ -43,6 +43,7 @@
     <Compile Include="..\SolutionVersion.cs">
       <Link>Properties\SolutionVersion.cs</Link>
     </Compile>
+    <Compile Include="MetricsInitializerFake.cs" />
     <Compile Include="ConsoleLog.cs" />
     <Compile Include="DateTimeFake.cs" />
     <Compile Include="Discovery\AlwaysLocalHost.cs" />

--- a/Gigya.Microdot.Fakes/MetricsInitializerFake.cs
+++ b/Gigya.Microdot.Fakes/MetricsInitializerFake.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Threading.Tasks;
+using Gigya.Microdot.Interfaces;
+using Gigya.Microdot.Interfaces.Logging;
+using Metrics;
+
+namespace Gigya.Microdot.Fakes
+{
+    public class MetricsInitializerFake : IMetricsInitializer
+    {
+
+        public void Init()
+        {
+            Metrics.Logging.LogProvider.SetCurrentLogProvider(null);
+
+            MetricsConfig = Metric.Config.WithErrorHandler(ex => {
+                Log.Error(_ => _("", ex));
+            }, true);
+        }
+
+        public void Shutdown()
+        {
+            try
+            {
+                MetricsConfig.Dispose();
+            }
+            catch (AggregateException ae)
+            {
+                // Ignore all TaskCanceledExceptions (unhandled by Metrics.NET for unknown reasons)
+                ae.Handle(ex => ex is TaskCanceledException);
+            }
+        }
+
+        public MetricsConfig MetricsConfig { get; private set; }
+
+        private IMetricsSettings MetricsSettings { get; set; }
+
+        private ILog Log { get; }
+
+        public MetricsInitializerFake(ILog log, IMetricsSettings metricsSettings)
+        {
+            MetricsSettings = metricsSettings;
+            Log = log;
+        }
+
+        public void Dispose()
+        {
+            MetricsConfig?.Dispose();
+        }
+    }
+}

--- a/Gigya.Microdot.Fakes/MetricsInitializerFake.cs
+++ b/Gigya.Microdot.Fakes/MetricsInitializerFake.cs
@@ -6,7 +6,7 @@ using Metrics;
 
 namespace Gigya.Microdot.Fakes
 {
-    public class MetricsInitializerFake : IMetricsInitializer
+    public sealed class MetricsInitializerFake : IMetricsInitializer
     {
 
         public void Init()
@@ -18,7 +18,7 @@ namespace Gigya.Microdot.Fakes
             }, true);
         }
 
-        public void Shutdown()
+        public void Dispose()
         {
             try
             {
@@ -43,9 +43,5 @@ namespace Gigya.Microdot.Fakes
             Log = log;
         }
 
-        public void Dispose()
-        {
-            MetricsConfig?.Dispose();
-        }
     }
 }

--- a/Gigya.Microdot.Hosting/Gigya.Microdot.Hosting.csproj
+++ b/Gigya.Microdot.Hosting/Gigya.Microdot.Hosting.csproj
@@ -117,17 +117,6 @@
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5.1'">
       <ItemGroup>
-        <Reference Include="Ninject">
-          <HintPath>..\packages\Ninject\lib\net45-full\Ninject.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5.1'">
-      <ItemGroup>
         <Reference Include="Metrics">
           <HintPath>..\packages\Metrics.NET\lib\net45\Metrics.dll</HintPath>
           <Private>True</Private>

--- a/Gigya.Microdot.Hosting/Gigya.Microdot.Hosting.csproj
+++ b/Gigya.Microdot.Hosting/Gigya.Microdot.Hosting.csproj
@@ -71,6 +71,7 @@
     <Compile Include="HttpService\ServiceEndPointDefinition.cs" />
     <Compile Include="HttpService\ServiceMethod.cs" />
     <Compile Include="HttpService\ServiceMethodResolver.cs" />
+    <Compile Include="Metrics\MetricsInitializer.cs" />
     <Compile Include="Service\GigyaServiceHost.cs" />
     <Compile Include="Service\HostExtensionMethods.cs" />
     <Compile Include="HttpService\Endpoints\HealthStatusResult.cs" />
@@ -113,6 +114,17 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5.1'">
+      <ItemGroup>
+        <Reference Include="Ninject">
+          <HintPath>..\packages\Ninject\lib\net45-full\Ninject.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5.1'">
       <ItemGroup>

--- a/Gigya.Microdot.Hosting/Metrics/MetricsInitializer.cs
+++ b/Gigya.Microdot.Hosting/Metrics/MetricsInitializer.cs
@@ -12,8 +12,9 @@ using Metrics.Logging;
 
 namespace Gigya.Microdot.Hosting.Metrics
 {
-    public class MetricsInitializer : IMetricsInitializer
+    public sealed class MetricsInitializer : IMetricsInitializer
     {
+        private bool _disposed;
         public MetricsConfig MetricsConfig { get; private set; }
         private IMetricsSettings MetricsSettings { get; }
         public HealthMonitor HealthMonitor { get; set; }
@@ -67,10 +68,13 @@ namespace Gigya.Microdot.Hosting.Metrics
 
         public void Dispose()
         {
+            if (_disposed)
+                return;
             try
             {
+                _disposed = true;
                 MetricsConfig.Dispose();
-                HealthMonitor.Dispose();
+                HealthMonitor.Dispose();                
             }
             catch (AggregateException ae)
             {

--- a/Gigya.Microdot.Hosting/Metrics/MetricsInitializer.cs
+++ b/Gigya.Microdot.Hosting/Metrics/MetricsInitializer.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Net;
+using System.Threading.Tasks;
+using Gigya.Common.Contracts.Exceptions;
+using Gigya.Microdot.Interfaces;
+using Gigya.Microdot.Interfaces.Configuration;
+using Gigya.Microdot.Interfaces.Logging;
+using Gigya.Microdot.SharedLogic;
+using Gigya.Microdot.SharedLogic.Monitor;
+using Metrics;
+using Metrics.Logging;
+
+namespace Gigya.Microdot.Hosting.Metrics
+{
+    public class MetricsInitializer : IMetricsInitializer
+    {
+        public MetricsConfig MetricsConfig { get; private set; }
+        private IMetricsSettings MetricsSettings { get; }
+        public HealthMonitor HealthMonitor { get; set; }
+        private ILog Log { get; }
+        private IEnvironmentVariableProvider EnvProvider { get; }
+
+
+        public MetricsInitializer(ILog log, IMetricsSettings metricsSettings, HealthMonitor healthMonitor, IEnvironmentVariableProvider envProvider)
+        {
+            MetricsSettings = metricsSettings;
+            HealthMonitor = healthMonitor;
+            Log = log;
+            EnvProvider = envProvider;
+        }
+
+        public void Init()
+        {
+            var metricsPort = MetricsSettings.MetricsPort;
+            Log.Info(_ => _("Initializing Metrics", unencryptedTags: new { port = metricsPort }));
+
+            LogProvider.SetCurrentLogProvider(null);
+            Exception metricsException = null;
+
+            Metric.Config.WithErrorHandler(ex =>
+            {
+                if (metricsException != null)
+                    metricsException = ex;
+            }, true);
+
+            MetricsConfig = Metric.Config.WithHttpEndpoint($"http://+:{metricsPort}/");
+
+            if (metricsException != null)
+            {
+                var exception = metricsException as HttpListenerException;
+                if (exception != null && exception.ErrorCode == 5)
+                {
+                    throw new EnvironmentException(
+                        $"Port {metricsPort} defined for Metrics.NET wasn't configured to run without administrative premissions.\nRun:\n" +
+                        $"netsh http add urlacl url=http://+:{metricsPort}/ user={CurrentApplicationInfo.OsUser}", metricsException);
+                }
+
+                throw new EnvironmentException("Problem loading metrics.net", metricsException);
+            }
+
+            Metric.Config.WithErrorHandler(ex =>
+            {
+                Log.Error(_ => _("Metrics Error", exception: ex));
+            }, true);
+        }
+
+
+        public void Dispose()
+        {
+            try
+            {
+                MetricsConfig.Dispose();
+                HealthMonitor.Dispose();
+            }
+            catch (AggregateException ae)
+            {
+                // Ignore all TaskCanceledExceptions (unhandled by Metrics.NET for unknown reasons)
+                ae.Handle(ex => ex is TaskCanceledException);
+            }
+        }
+    }
+}

--- a/Gigya.Microdot.Hosting/Service/GigyaServiceHost.cs
+++ b/Gigya.Microdot.Hosting/Service/GigyaServiceHost.cs
@@ -28,9 +28,8 @@ using System.Runtime.CompilerServices;
 using System.ServiceProcess;
 using System.Threading;
 using System.Threading.Tasks;
-using Gigya.Microdot.Interfaces;
 using Gigya.Microdot.SharedLogic;
-using Ninject;
+
 
 [assembly: InternalsVisibleTo("LINQPadQuery")]
 
@@ -177,19 +176,6 @@ namespace Gigya.Microdot.Hosting.Service
                     Console.ReadKey(true);
                 }
             }
-        }
-
-        /// <summary>
-        /// Used to initialize service dependencies. This method is called before OnInitialize(), 
-        /// and should include common behaviour for a family of services. 
-        /// When overriden on the family services base, it is recommended to mark it as sealed, 
-        /// to prevent concrete services from overriding the common behaviour. 
-        /// </summary>
-        /// <param name="kernel"></param>
-        protected virtual void PreInitialize(IKernel kernel)
-        {
-            var metricsInitializer = kernel.TryGet<IMetricsInitializer>();
-            metricsInitializer?.Init();
         }
 
         /// <summary>

--- a/Gigya.Microdot.Interfaces/Gigya.Microdot.Interfaces.csproj
+++ b/Gigya.Microdot.Interfaces/Gigya.Microdot.Interfaces.csproj
@@ -56,6 +56,7 @@
     <Compile Include="IApplicationDirectoryProvider.cs" />
     <Compile Include="IAssemblyProvider.cs" />
     <Compile Include="ICacheRevoker.cs" />
+    <Compile Include="IMetricsInitializer.cs" />
     <Compile Include="IMetricsSettings.cs" />
     <Compile Include="Logging\ILog.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Gigya.Microdot.Interfaces/IMetricsInitializer.cs
+++ b/Gigya.Microdot.Interfaces/IMetricsInitializer.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Gigya.Microdot.Interfaces
+{
+    public interface IMetricsInitializer: IDisposable
+    {
+        void Init();
+    }
+}

--- a/Gigya.Microdot.Ninject.Host/MicrodotServiceHost.cs
+++ b/Gigya.Microdot.Ninject.Host/MicrodotServiceHost.cs
@@ -83,6 +83,19 @@ namespace Gigya.Microdot.Ninject.Host
         }
 
         /// <summary>
+        /// Used to initialize service dependencies. This method is called before OnInitialize(), 
+        /// and should include common behaviour for a family of services. 
+        /// When overriden on the family services base, it is recommended to mark it as sealed, 
+        /// to prevent concrete services from overriding the common behaviour. 
+        /// </summary>
+        /// <param name="kernel"></param>
+        protected virtual void PreInitialize(IKernel kernel)
+        {
+            var metricsInitializer = kernel.Get<IMetricsInitializer>();
+            metricsInitializer.Init();
+        }
+
+        /// <summary>
         /// Extensibility point - this method is called after the Kernel is configured and before service starts
         /// processing incoming request.
         /// </summary>

--- a/Gigya.Microdot.Ninject.Host/MicrodotServiceHost.cs
+++ b/Gigya.Microdot.Ninject.Host/MicrodotServiceHost.cs
@@ -23,6 +23,7 @@
 using System;
 using Gigya.Microdot.Hosting.HttpService;
 using Gigya.Microdot.Hosting.Service;
+using Gigya.Microdot.Interfaces;
 using Gigya.Microdot.Interfaces.Events;
 using Gigya.Microdot.Interfaces.Logging;
 using Gigya.Microdot.SharedLogic;
@@ -74,6 +75,7 @@ namespace Gigya.Microdot.Ninject.Host
 
             Configure(Kernel, Kernel.Get<BaseCommonConfig>());
 
+            PreInitialize(Kernel);
             OnInitilize(Kernel);
 
             Listener = Kernel.Get<HttpServiceListener>();
@@ -125,8 +127,7 @@ namespace Gigya.Microdot.Ninject.Host
             GetLoggingModule().Bind(kernel.Rebind<ILog>(), kernel.Rebind<IEventPublisher>());
             kernel.Rebind<ServiceArguments>().ToConstant(Arguments);
         }
-        
-        
+
         /// <summary>
         /// When overridden, allows a service to configure its Ninject bindings and infrastructure features. Called
         /// after infrastructure was binded but before the silo is started. You must bind an implementation to the
@@ -145,6 +146,7 @@ namespace Gigya.Microdot.Ninject.Host
         protected override void OnStop()
         {
             Listener.Dispose();
+            Kernel.Dispose();
         }
     }
 }

--- a/Gigya.Microdot.Orleans.Ninject.Host/MicrodotOrleansServiceHost.cs
+++ b/Gigya.Microdot.Orleans.Ninject.Host/MicrodotOrleansServiceHost.cs
@@ -22,6 +22,7 @@
 
 using System.Threading.Tasks;
 using Gigya.Microdot.Hosting.Service;
+using Gigya.Microdot.Interfaces;
 using Gigya.Microdot.Interfaces.Events;
 using Gigya.Microdot.Interfaces.Logging;
 using Gigya.Microdot.Ninject;
@@ -69,6 +70,19 @@ namespace Gigya.Microdot.Orleans.Ninject.Host
 
             SiloHost = Kernel.Get<GigyaSiloHost>();            
             SiloHost.Start(AfterOrleansStartup, BeforeOrleansShutdown);
+        }
+
+        /// <summary>
+        /// Used to initialize service dependencies. This method is called before OnInitialize(), 
+        /// and should include common behaviour for a family of services. 
+        /// When overriden on the family services base, it is recommended to mark it as sealed, 
+        /// to prevent concrete services from overriding the common behaviour. 
+        /// </summary>
+        /// <param name="kernel"></param>
+        protected virtual void PreInitialize(IKernel kernel)
+        {
+            var metricsInitializer = kernel.Get<IMetricsInitializer>();
+            metricsInitializer.Init();
         }
 
         /// <summary>

--- a/Gigya.Microdot.Orleans.Ninject.Host/MicrodotOrleansServiceHost.cs
+++ b/Gigya.Microdot.Orleans.Ninject.Host/MicrodotOrleansServiceHost.cs
@@ -64,6 +64,7 @@ namespace Gigya.Microdot.Orleans.Ninject.Host
 
             Kernel.Get<ClusterConfiguration>().WithNinject(Kernel);
 
+            PreInitialize(Kernel);
             OnInitilize(Kernel);
 
             SiloHost = Kernel.Get<GigyaSiloHost>();            
@@ -145,6 +146,7 @@ namespace Gigya.Microdot.Orleans.Ninject.Host
         protected override void OnStop()
         {
             SiloHost.Stop(); // This calls BeforeOrleansShutdown()
+            Dispose();
         }
 
 

--- a/Gigya.Microdot.Testing/TestingKernel.cs
+++ b/Gigya.Microdot.Testing/TestingKernel.cs
@@ -26,6 +26,7 @@ using System.Linq;
 using Gigya.Microdot.Configuration;
 using Gigya.Microdot.Fakes;
 using Gigya.Microdot.Fakes.Discovery;
+using Gigya.Microdot.Interfaces;
 using Gigya.Microdot.Interfaces.Events;
 using Gigya.Microdot.Interfaces.Logging;
 using Gigya.Microdot.Ninject;
@@ -55,6 +56,7 @@ namespace Gigya.Microdot.Testing
             var locationsParserMock = Substitute.For<IConfigurationLocationsParser>();
             locationsParserMock.ConfigFileDeclarations.Returns(Enumerable.Empty<ConfigFileDeclaration>().ToArray());
             Rebind<IConfigurationLocationsParser>().ToConstant(locationsParserMock);
+            Rebind<IMetricsInitializer>().To<MetricsInitializerFake>().InSingletonScope();
 
             additionalBindings?.Invoke(this);
 

--- a/tests/Gigya.Microdot.Orleans.Hosting.UnitTests/AssemblyInitialize.cs
+++ b/tests/Gigya.Microdot.Orleans.Hosting.UnitTests/AssemblyInitialize.cs
@@ -51,6 +51,7 @@ namespace Gigya.Microdot.Orleans.Hosting.UnitTests
                     var revokingManager = new FakeRevokingManager();
                     kernel.Rebind<IRevokeListener>().ToConstant(revokingManager);
                     kernel.Rebind<ICacheRevoker>().ToConstant(revokingManager);
+                    kernel.Rebind<IMetricsInitializer>().To<MetricsInitializerFake>();
                 });            
                 ResolutionRoot = kernel;
             }

--- a/tests/Gigya.Microdot.UnitTests/TestingHost.cs
+++ b/tests/Gigya.Microdot.UnitTests/TestingHost.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Gigya.Microdot.Configuration;
 using Gigya.Microdot.Fakes;
 using Gigya.Microdot.Hosting.HttpService;
+using Gigya.Microdot.Interfaces;
 using Gigya.Microdot.Interfaces.Events;
 using Gigya.Microdot.Interfaces.Logging;
 using Gigya.Microdot.Ninject;
@@ -42,8 +43,8 @@ namespace Gigya.Microdot.UnitTests
 
             kernel.Rebind<IEventPublisher>().To<NullEventPublisher>();
             kernel.Rebind<IWorker>().To<WaitingWorker>();
+            kernel.Rebind<IMetricsInitializer>().To<MetricsInitializerFake>().InSingletonScope();
 
- 
             kernel.Bind<T>().ToConstant(Substitute.For<T>());
 
             optionalConfigs?.Invoke(kernel);


### PR DESCRIPTION
Initialize METRICS.NET to start listening on Service's port+3 when application is loaded