### PR TITLE
Added ProcessorAffinity service argument

### DIFF
--- a/Gigya.Microdot.Hosting/HttpService/Endpoints/ConfigurationResponseBuilder.cs
+++ b/Gigya.Microdot.Hosting/HttpService/Endpoints/ConfigurationResponseBuilder.cs
@@ -71,6 +71,7 @@ namespace Gigya.Microdot.Hosting.HttpService.Endpoints
                 EnvironmentVariables = GetEnvironmentVariables(),
                 AssemblyVersions = GetAssemblyVersions(),
                 RuntimeInfo = GetRuntimeInfo(),
+                ServiceArguments = GetServiceArguments(),
                 ConfigurationEntries = GetConfigurationEntries()
             };
 

--- a/Gigya.Microdot.Hosting/HttpService/Endpoints/ConfigurationResponseBuilder.cs
+++ b/Gigya.Microdot.Hosting/HttpService/Endpoints/ConfigurationResponseBuilder.cs
@@ -144,7 +144,7 @@ namespace Gigya.Microdot.Hosting.HttpService.Endpoints
             var runtime = JsonConvert.SerializeObject(GetRuntimeInfo()).GetHashCode();
             var arguments = JsonConvert.SerializeObject(GetServiceArguments()).GetHashCode();
             var config = JsonConvert.SerializeObject(GetConfigurationEntries()).GetHashCode();
-            var all = ((env * 397 ^ ver) * 397 ^ runtime) * 397 ^ config;
+            var all = (((env * 397 ^ ver) * 397 ^ runtime) * 397 ^ arguments) * 397 ^ config;
 
             return new Dictionary<string, int>
             {

--- a/Gigya.Microdot.Hosting/HttpService/Endpoints/ConfigurationResponseBuilder.cs
+++ b/Gigya.Microdot.Hosting/HttpService/Endpoints/ConfigurationResponseBuilder.cs
@@ -43,6 +43,7 @@ namespace Gigya.Microdot.Hosting.HttpService.Endpoints
         JsonSerializerSettings JsonSettings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore, Formatting = Formatting.Indented};
 
         private UsageTracking UsageTracking { get; }
+        private ServiceArguments ServiceArguments { get; }
         private ConfigCache ConfigCache { get; }
         private IEnvironmentVariableProvider Envs { get; }
         private IAssemblyProvider AssemblyProvider { get; }
@@ -51,9 +52,11 @@ namespace Gigya.Microdot.Hosting.HttpService.Endpoints
         public ConfigurationResponseBuilder(ConfigCache configCache,
                                             IEnvironmentVariableProvider envs,
                                             IAssemblyProvider assemblyProvider,
-                                            UsageTracking usageTracking)
+                                            UsageTracking usageTracking,
+                                            ServiceArguments serviceArguments)
         {
             UsageTracking = usageTracking;
+            ServiceArguments = serviceArguments;
             ConfigCache = configCache;
             Envs = envs;
             AssemblyProvider = assemblyProvider;
@@ -109,6 +112,15 @@ namespace Gigya.Microdot.Hosting.HttpService.Endpoints
                 sb.AppendLine($"{info.Key.PadRight(maxNameLen)} = {info.Value}");
 
 
+            var serviceArguments = GetServiceArguments();
+            maxNameLen = serviceArguments.Keys.Select(k => k.Length).Max();
+
+            sb.AppendLine($"\n\n\n===       Service Arguments (hash {hashes["ServiceArguments"]})        ===\n");
+
+            foreach (var info in serviceArguments)
+                sb.AppendLine($"{info.Key.PadRight(maxNameLen)} = {info.Value}");
+
+
             sb.AppendLine($"\n\n\n===   Configuration Entries (hash {hashes["ConfigurationEntries"]})   ===\n");
 
             var configItems = GetConfigurationEntries();
@@ -129,6 +141,7 @@ namespace Gigya.Microdot.Hosting.HttpService.Endpoints
             var env = JsonConvert.SerializeObject(GetEnvironmentVariables()).GetHashCode();
             var ver = JsonConvert.SerializeObject(GetAssemblyVersions()).GetHashCode();
             var runtime = JsonConvert.SerializeObject(GetRuntimeInfo()).GetHashCode();
+            var arguments = JsonConvert.SerializeObject(GetServiceArguments()).GetHashCode();
             var config = JsonConvert.SerializeObject(GetConfigurationEntries()).GetHashCode();
             var all = ((env * 397 ^ ver) * 397 ^ runtime) * 397 ^ config;
 
@@ -138,6 +151,7 @@ namespace Gigya.Microdot.Hosting.HttpService.Endpoints
                 { "EnvironmentVariables", env },
                 { "AssemblyVersions", ver },
                 { "RuntimeInfo", runtime },
+                { "ServiceArguments", arguments },
                 { "ConfigurationEntries", config }
             };
         }
@@ -205,6 +219,30 @@ namespace Gigya.Microdot.Hosting.HttpService.Endpoints
                 { "DefaultConnectionLimit", ServicePointManager.DefaultConnectionLimit.ToString() },
                 { "SecurityProtocol", ServicePointManager.SecurityProtocol.ToString() }
             };
+        }
+
+        private Dictionary<string, string> GetServiceArguments()
+        {
+            var dict = new Dictionary<string, string>();
+
+            foreach (var property in typeof(ServiceArguments).GetProperties())
+            {
+                var value = property.GetValue(ServiceArguments);
+
+                if (value != null && property.PropertyType.IsArray)
+                {
+                    var untypedArray = (Array)value;
+                    var typedArray = new object[untypedArray.Length];
+                    untypedArray.CopyTo(typedArray, 0);
+                    dict[property.Name] = string.Join(",", typedArray);
+                }
+                else
+                {
+                    dict[property.Name] = value?.ToString() ?? "<null>";
+                }
+            }
+
+            return dict;
         }
 
 

--- a/Gigya.Microdot.Hosting/Service/GigyaServiceHost.cs
+++ b/Gigya.Microdot.Hosting/Service/GigyaServiceHost.cs
@@ -73,6 +73,16 @@ namespace Gigya.Microdot.Hosting.Service
             Arguments = argumentsOverride ?? new ServiceArguments(Environment.GetCommandLineArgs().Skip(1).ToArray());
             CurrentApplicationInfo.Init(ServiceName, Arguments.InstanceName);
 
+            if (Arguments.ProcessorAffinity != null)
+            {
+                int processorAffinityMask = 0;
+
+                foreach (var cpuId in Arguments.ProcessorAffinity)
+                    processorAffinityMask |= 1 << cpuId;
+
+                Process.GetCurrentProcess().ProcessorAffinity = new IntPtr(processorAffinityMask);
+            }
+
             if (Arguments.ServiceStartupMode == ServiceStartupMode.WindowsService)
             {
                 Trace.WriteLine("Service starting as a Windows service...");

--- a/Gigya.Microdot.Orleans.Hosting/OrleansConfigurationBuilder.cs
+++ b/Gigya.Microdot.Orleans.Hosting/OrleansConfigurationBuilder.cs
@@ -45,10 +45,8 @@ namespace Gigya.Microdot.Orleans.Hosting
         public string ConnectionString { get; set; }
     }
 
-    public class OrleansConfig:IConfigObject
+    public class OrleansConfig : IConfigObject
     {
-        public int MaxActiveThreads { get; set; }
-
         public string MetricsTableWriteInterval { get; set; } = "00:00:01";
 
         public ZooKeeperConfig ZooKeeper { get; set; }
@@ -64,7 +62,7 @@ namespace Gigya.Microdot.Orleans.Hosting
 
 	    public OrleansConfigurationBuilder(OrleansConfig orleansConfig, OrleansCodeConfig commonConfig,
 	                                       ClusterConfiguration clusterConfiguration, ClusterIdentity clusterIdentity, IServiceEndPointDefinition endPointDefinition,
-	                                       OrleansLogConsumer orleansLogConsumer, ZooKeeperLogConsumer zooKeeperLogConsumer)
+	                                       OrleansLogConsumer orleansLogConsumer, ZooKeeperLogConsumer zooKeeperLogConsumer, ServiceArguments serviceArguments)
 	    {
 	        ClusterConfiguration = clusterConfiguration;
 
@@ -76,8 +74,8 @@ namespace Gigya.Microdot.Orleans.Hosting
 	        defaults.ProxyGatewayEndpoint = new IPEndPoint(IPAddress.Loopback, endPointDefinition.SiloGatewayPort);
 	        defaults.Port = endPointDefinition.SiloNetworkingPort;
 
-	        if(orleansConfig.MaxActiveThreads > 0)
-	            defaults.MaxActiveThreads = orleansConfig.MaxActiveThreads;
+	        if (serviceArguments.ProcessorAffinity != null)
+	            defaults.MaxActiveThreads = serviceArguments.ProcessorAffinity.Length;
 
 	        // Orleans log redirection
 	        defaults.TraceToConsole = false;

--- a/Gigya.Microdot.SharedLogic/ServiceArguments.cs
+++ b/Gigya.Microdot.SharedLogic/ServiceArguments.cs
@@ -71,6 +71,13 @@ namespace Gigya.Microdot.SharedLogic
         public int? ShutdownWhenPidExits { get; }
 
         /// <summary>
+        /// An array of processor IDs the service should run on, otherwise null if none are is specified. This also affects the degree
+        /// or parallism of the underlying runtime (e.g. the number of threads Orleans will be configured with). Mainly used for 
+        /// multi-tenant servers where multiple services run, each with dedicated CPU cores.
+        /// </summary>
+        public int[] ProcessorAffinity { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ServiceArguments"/> class, explicitly specifying the arguments.
         /// Typically used in tests.
         /// </summary>
@@ -108,10 +115,31 @@ namespace Gigya.Microdot.SharedLogic
             InstanceName = ParseStringArg(nameof(InstanceName), args);
             ShutdownWhenPidExits = TryParseInt(ParseStringArg(nameof(ShutdownWhenPidExits), args));
             SlotNumber = TryParseInt(ParseStringArg(nameof(SlotNumber), args));
+            ProcessorAffinity = ParseProcessorIds(ParseStringArg(nameof(ProcessorAffinity), args));
             ApplyDefaults();
         }
 
         private static int? TryParseInt(string str) { return int.TryParse(str, out int val) ? (int?)val : null; }
+
+        private static int[] ParseProcessorIds(string processorIdList)
+        {
+            var processorAffinity = processorIdList?
+                .Split(',')
+                .Select(TryParseInt)
+                .Where(i => i != null)
+                .Select(i => i.Value)
+                .Distinct()
+                .OrderBy(i => i)
+                .ToArray();
+
+            if (processorAffinity == null || processorAffinity.Length == 0)
+                return null;
+
+            if (processorAffinity.Any(id => id < 0 || id >= Environment.ProcessorCount))
+                throw new ArgumentOutOfRangeException(nameof(ProcessorAffinity), $"The specified processor affinity list contains an invalid processor ID. On this machine, processor IDs must be between 0 and {Environment.ProcessorCount - 1}, inclusive.");
+
+            return processorAffinity;
+        }
 
 
         private void ApplyDefaults()


### PR DESCRIPTION
...allowing to specify which processors should be used by the service (and adjust Orleans thread count accordingly). Removed OrleansConfig.MaxActiveThreads configuration. Added all ServiceArguments properties to configuration endpoint.