### PR TITLE
Service call parameters can now be left unencrypted in serverReq event

### DIFF
--- a/Gigya.Microdot.Hosting/Events/ServiceCallEvent.cs
+++ b/Gigya.Microdot.Hosting/Events/ServiceCallEvent.cs
@@ -48,7 +48,7 @@ namespace Gigya.Microdot.Hosting.Events
         [EventField(EventConsts.srvService)]
         internal string CalledServiceName { get; set; }
 
-        /// <summary>The name of the calling  system (comments/socialize/hades/mongo etc)</summary>
+        /// <summary>The name of the calling  system (comments/s ocialize/hades/mongo etc)</summary>
         [EventField("cln.system")]
         public string CallerServiceName => ClientMetadata?.ServiceName;
 
@@ -60,18 +60,18 @@ namespace Gigya.Microdot.Hosting.Events
         [EventField(EventConsts.targetMethod)]
         public string ServiceMethod { get; set; }
 
-        /// <summary>  Encrypted Service method arguments </summary>
+        /// <summary>  Sensitive Service method arguments </summary>
         [EventField("params", Encrypt = true)]
         public IEnumerable<KeyValuePair<string, string>> EncryptedServiceMethodArguments => LazyEncryptedRequestParams.GetValue(this);
 
-        /// <summary> Unencrypted Service method arguments </summary>
+        /// <summary> NonSensitive Service method arguments </summary>
 
         [EventField("params", Encrypt = false)]
         public IEnumerable<KeyValuePair<string, string>> UnencryptedServiceMethodArguments => LazyUnencryptedRequestParams.GetValue(this);
 
 
-        private readonly SharedLogic.Utils.Lazy<List<KeyValuePair<string, string>>, ServiceCallEvent> LazyEncryptedRequestParams = new SharedLogic.Utils.Lazy<List<KeyValuePair<string, string>>, ServiceCallEvent>(this_ => this_.GetRequestParams(Sensitivity.Encrypted).ToList());
-        private readonly SharedLogic.Utils.Lazy<List<KeyValuePair<string, string>>, ServiceCallEvent> LazyUnencryptedRequestParams = new SharedLogic.Utils.Lazy<List<KeyValuePair<string, string>>, ServiceCallEvent>(this_ => this_.GetRequestParams(Sensitivity.Unencrypted).ToList());
+        private readonly SharedLogic.Utils.Lazy<List<KeyValuePair<string, string>>, ServiceCallEvent> LazyEncryptedRequestParams = new SharedLogic.Utils.Lazy<List<KeyValuePair<string, string>>, ServiceCallEvent>(this_ => this_.GetRequestParams(Sensitivity.Sensitive).ToList());
+        private readonly SharedLogic.Utils.Lazy<List<KeyValuePair<string, string>>, ServiceCallEvent> LazyUnencryptedRequestParams = new SharedLogic.Utils.Lazy<List<KeyValuePair<string, string>>, ServiceCallEvent>(this_ => this_.GetRequestParams(Sensitivity.NonSensitive).ToList());
 
 
         public IEnumerable<Param> Params { get; set; }

--- a/Gigya.Microdot.Hosting/Gigya.Microdot.Hosting.csproj
+++ b/Gigya.Microdot.Hosting/Gigya.Microdot.Hosting.csproj
@@ -48,6 +48,7 @@
     <Compile Include="..\SolutionVersion.cs">
       <Link>Properties\SolutionVersion.cs</Link>
     </Compile>
+    <Compile Include="HttpService\EndPointMetaData.cs" />
     <Compile Include="HttpService\Endpoints\ConfigurationResponseBuilder.cs" />
     <Compile Include="HostingAssembly.cs" />
     <Compile Include="Events\StatsEvent.cs" />

--- a/Gigya.Microdot.Hosting/HttpService/EndPointMetaData.cs
+++ b/Gigya.Microdot.Hosting/HttpService/EndPointMetaData.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using Gigya.Microdot.SharedLogic.Events;
+using Gigya.ServiceContract.Attributes;
+
+namespace Gigya.Microdot.Hosting.HttpService
+{
+    public class EndPointMetaData
+    {
+        public EndPointMetaData(ServiceMethod method)
+        {
+            MethodSensitivity = GetSensitivity(method.ServiceInterfaceMethod);
+
+            var parametersSensitivity = ImmutableDictionary.CreateBuilder<string, Sensitivity?>();
+
+            foreach (var pram in method.ServiceInterfaceMethod.GetParameters())
+            {
+                parametersSensitivity.Add(pram.Name, GetSensitivity(pram));
+            }
+
+            ParametersSensitivity = parametersSensitivity.ToImmutable();
+        }
+
+        private Sensitivity? GetSensitivity(ICustomAttributeProvider t)
+        {
+
+            var attribute = t.GetCustomAttributes(typeof(SensitiveAttribute),true).FirstOrDefault();
+            if (attribute is SensitiveAttribute sensitiveAttribute)
+            {
+                if (sensitiveAttribute.DoNotLog)
+                    return Sensitivity.NoLog;
+                return Sensitivity.Encrypted;
+
+            }
+
+            attribute = t.GetCustomAttributes(typeof(NonSensitiveAttribute), true).FirstOrDefault();
+            if (attribute is NonSensitiveAttribute)
+            {
+                return Sensitivity.Unencrypted;
+            }
+            return null;
+        }
+
+        public ImmutableDictionary<string, Sensitivity?> ParametersSensitivity { get; }
+
+        public Sensitivity? MethodSensitivity { get; }
+
+    }
+
+}

--- a/Gigya.Microdot.Hosting/HttpService/EndPointMetaData.cs
+++ b/Gigya.Microdot.Hosting/HttpService/EndPointMetaData.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
@@ -7,9 +6,9 @@ using Gigya.ServiceContract.Attributes;
 
 namespace Gigya.Microdot.Hosting.HttpService
 {
-    public class EndPointMetaData
+    public class EndPointMetadata
     {
-        public EndPointMetaData(ServiceMethod method)
+        public EndPointMetadata(ServiceMethod method)
         {
             MethodSensitivity = GetSensitivity(method.ServiceInterfaceMethod);
 
@@ -29,16 +28,16 @@ namespace Gigya.Microdot.Hosting.HttpService
             var attribute = t.GetCustomAttributes(typeof(SensitiveAttribute),true).FirstOrDefault();
             if (attribute is SensitiveAttribute sensitiveAttribute)
             {
-                if (sensitiveAttribute.DoNotLog)
-                    return Sensitivity.NoLog;
-                return Sensitivity.Encrypted;
+                if (sensitiveAttribute.Secretive)
+                    return Sensitivity.Secretive;
+                return Sensitivity.Sensitive;
 
             }
 
             attribute = t.GetCustomAttributes(typeof(NonSensitiveAttribute), true).FirstOrDefault();
             if (attribute is NonSensitiveAttribute)
             {
-                return Sensitivity.Unencrypted;
+                return Sensitivity.NonSensitive;
             }
             return null;
         }

--- a/Gigya.Microdot.Hosting/HttpService/HttpServiceListener.cs
+++ b/Gigya.Microdot.Hosting/HttpService/HttpServiceListener.cs
@@ -358,11 +358,16 @@ namespace Gigya.Microdot.Hosting.HttpService
             callEvent.CalledServiceName = serviceMethod?.GrainInterfaceType.Name;
             callEvent.ClientMetadata = requestData.TracingData;
             callEvent.ServiceMethod = requestData.Target?.MethodName;
+
+            var metaData = ServiceEndPointDefinition.GetMetaData(serviceMethod);
+
             callEvent.Params = (requestData.Arguments ?? new OrderedDictionary()).Cast<DictionaryEntry>().Select(arg => new Param
             {
                 Name = arg.Key.ToString(),
-                Value = arg.Value is string ? arg.Value.ToString() : JsonConvert.SerializeObject(arg.Value)
+                Value = arg.Value is string ? arg.Value.ToString() : JsonConvert.SerializeObject(arg.Value),
+                Sensitivity = metaData.ParametersSensitivity[arg.Key.ToString()] ?? metaData.MethodSensitivity ?? Sensitivity.Encrypted
             });
+
             callEvent.Exception = ex;
             callEvent.ActualTotalTime = requestTime;
             callEvent.ErrCode = ex != null ? null : (int?)0;

--- a/Gigya.Microdot.Hosting/HttpService/HttpServiceListener.cs
+++ b/Gigya.Microdot.Hosting/HttpService/HttpServiceListener.cs
@@ -365,7 +365,7 @@ namespace Gigya.Microdot.Hosting.HttpService
             {
                 Name = arg.Key.ToString(),
                 Value = arg.Value is string ? arg.Value.ToString() : JsonConvert.SerializeObject(arg.Value),
-                Sensitivity = metaData.ParametersSensitivity[arg.Key.ToString()] ?? metaData.MethodSensitivity ?? Sensitivity.Encrypted
+                Sensitivity = metaData.ParametersSensitivity[arg.Key.ToString()] ?? metaData.MethodSensitivity ?? Sensitivity.Sensitive
             });
 
             callEvent.Exception = ex;

--- a/Gigya.Microdot.Hosting/HttpService/IServiceEndPointDefinition.cs
+++ b/Gigya.Microdot.Hosting/HttpService/IServiceEndPointDefinition.cs
@@ -67,7 +67,7 @@ namespace Gigya.Microdot.Hosting.HttpService
         /// <returns></returns>
 	    ServiceMethod[] GetAll();
 
-        EndPointMetaData GetMetaData(ServiceMethod method);
+        EndPointMetadata GetMetaData(ServiceMethod method);
 
     }
 }

--- a/Gigya.Microdot.Hosting/HttpService/IServiceEndPointDefinition.cs
+++ b/Gigya.Microdot.Hosting/HttpService/IServiceEndPointDefinition.cs
@@ -66,5 +66,8 @@ namespace Gigya.Microdot.Hosting.HttpService
         /// </summary>
         /// <returns></returns>
 	    ServiceMethod[] GetAll();
+
+        EndPointMetaData GetMetaData(ServiceMethod method);
+
     }
 }

--- a/Gigya.Microdot.Hosting/HttpService/ServiceEndPointDefinition.cs
+++ b/Gigya.Microdot.Hosting/HttpService/ServiceEndPointDefinition.cs
@@ -21,6 +21,7 @@
 #endregion
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -52,6 +53,8 @@ namespace Gigya.Microdot.Hosting.HttpService
         public int SiloNetworkingPortOfPrimaryNode { get; }
 
         public Dictionary<Type, string> ServiceNames { get; }
+
+        private ConcurrentDictionary<ServiceMethod,  EndPointMetaData> _metadata= new ConcurrentDictionary<ServiceMethod, EndPointMetaData>();
 
         private readonly ServiceMethodResolver _serviceMethodResolver;
 
@@ -132,12 +135,22 @@ namespace Gigya.Microdot.Hosting.HttpService
                 SiloNetworkingPort = config.PortAllocation.GetPort(slotNumber, PortOffsets.SiloNetworking).Value;
                 SiloNetworkingPortOfPrimaryNode = config.PortAllocation.GetPort(serviceConfig.DefaultSlotNumber, PortOffsets.SiloNetworking).Value;
             }
+
+            foreach (var method in _serviceMethodResolver.GrainMethods)
+            {
+                GetMetaData(method);
+            }
         }
 
 
         public ServiceMethod Resolve(InvocationTarget target)
         {
             return _serviceMethodResolver.Resolve(target);
+        }
+        public EndPointMetaData GetMetaData(ServiceMethod method)
+        {
+            return _metadata.GetOrAdd(method, m => new EndPointMetaData(m));
+
         }
 
 

--- a/Gigya.Microdot.Hosting/HttpService/ServiceEndPointDefinition.cs
+++ b/Gigya.Microdot.Hosting/HttpService/ServiceEndPointDefinition.cs
@@ -54,7 +54,7 @@ namespace Gigya.Microdot.Hosting.HttpService
 
         public Dictionary<Type, string> ServiceNames { get; }
 
-        private ConcurrentDictionary<ServiceMethod,  EndPointMetaData> _metadata= new ConcurrentDictionary<ServiceMethod, EndPointMetaData>();
+        private ConcurrentDictionary<ServiceMethod,  EndPointMetadata> _metadata= new ConcurrentDictionary<ServiceMethod, EndPointMetadata>();
 
         private readonly ServiceMethodResolver _serviceMethodResolver;
 
@@ -147,9 +147,9 @@ namespace Gigya.Microdot.Hosting.HttpService
         {
             return _serviceMethodResolver.Resolve(target);
         }
-        public EndPointMetaData GetMetaData(ServiceMethod method)
+        public EndPointMetadata GetMetaData(ServiceMethod method)
         {
-            return _metadata.GetOrAdd(method, m => new EndPointMetaData(m));
+            return _metadata.GetOrAdd(method, m => new EndPointMetadata(m));
 
         }
 

--- a/Gigya.Microdot.SharedLogic/Events/Param.cs
+++ b/Gigya.Microdot.SharedLogic/Events/Param.cs
@@ -37,6 +37,8 @@ namespace Gigya.Microdot.SharedLogic.Events
     [Serializable]
     public enum Sensitivity
     {
-        Encrypted, Unencrypted, NoLog
+        Sensitive,
+        NonSensitive,
+        Secretive
     }
 }

--- a/Gigya.Microdot.SharedLogic/Events/Param.cs
+++ b/Gigya.Microdot.SharedLogic/Events/Param.cs
@@ -31,5 +31,12 @@ namespace Gigya.Microdot.SharedLogic.Events
     {
         public string Name;
         public string Value;
+        public Sensitivity Sensitivity;
+    }
+
+    [Serializable]
+    public enum Sensitivity
+    {
+        Encrypted, Unencrypted, NoLog
     }
 }

--- a/Gigya.ServiceContract/Attributes/EventAttrubute.cs
+++ b/Gigya.ServiceContract/Attributes/EventAttrubute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Gigya.ServiceContract.Attributes
+{
+    [AttributeUsage(AttributeTargets.Parameter| AttributeTargets.Method)]
+
+    public class SensitiveAttribute : Attribute
+    {
+        public bool DoNotLog { get; set; }
+    }
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
+
+    public class NonSensitiveAttribute : Attribute{}
+
+}

--- a/Gigya.ServiceContract/Attributes/EventAttrubute.cs
+++ b/Gigya.ServiceContract/Attributes/EventAttrubute.cs
@@ -6,7 +6,7 @@ namespace Gigya.ServiceContract.Attributes
 
     public class SensitiveAttribute : Attribute
     {
-        public bool DoNotLog { get; set; }
+        public bool Secretive { get; set; }
     }
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
 

--- a/Gigya.ServiceContract/Gigya.ServiceContract.csproj
+++ b/Gigya.ServiceContract/Gigya.ServiceContract.csproj
@@ -39,6 +39,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Attributes\CachedAttribute.cs" />
+    <Compile Include="Attributes\EventAttrubute.cs" />
     <Compile Include="Attributes\HttpServiceAttribute.cs" />
     <Compile Include="Attributes\PublicEndpointAttribute.cs" />
     <Compile Include="Exceptions\EnvironmentException.cs" />

--- a/Gigya.ServiceContract/Properties/AssemblyInfo.cs
+++ b/Gigya.ServiceContract/Properties/AssemblyInfo.cs
@@ -40,9 +40,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 
 
-[assembly: AssemblyInformationalVersion("2.4.15")]// if pre-release should be in the format of "2.4.11-pre01".
-[assembly: AssemblyVersion("2.4.15")]
-[assembly: AssemblyFileVersion("2.4.15")]
+[assembly: AssemblyInformationalVersion("2.4.16-pre01")]// if pre-release should be in the format of "2.4.11-pre01".
+[assembly: AssemblyVersion("2.4.16")]
+[assembly: AssemblyFileVersion("2.4.16")]
 
 [assembly: AssemblyDescription("")]
 

--- a/SolutionVersion.cs
+++ b/SolutionVersion.cs
@@ -28,9 +28,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("© 2017 Gigya Inc.")]
 [assembly: AssemblyDescription("Microdot Framework")]
 
-[assembly: AssemblyVersion("1.5.6.0")]
-[assembly: AssemblyFileVersion("1.5.6.0")] 
-[assembly: AssemblyInformationalVersion("1.5.6.0")]
+[assembly: AssemblyVersion("1.6.0.0")]
+[assembly: AssemblyFileVersion("1.6.0.0")] 
+[assembly: AssemblyInformationalVersion("1.6.0.0")]
 
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/tests/Gigya.Microdot.Orleans.Hosting.UnitTests/AssemblyInitialize.cs
+++ b/tests/Gigya.Microdot.Orleans.Hosting.UnitTests/AssemblyInitialize.cs
@@ -23,6 +23,7 @@
 using System;
 using Gigya.Microdot.Fakes;
 using Gigya.Microdot.Interfaces;
+using Gigya.Microdot.Interfaces.Events;
 using Gigya.Microdot.Orleans.Hosting.UnitTests.Microservice;
 using Gigya.Microdot.ServiceProxy.Caching;
 using Gigya.Microdot.Testing;
@@ -52,6 +53,8 @@ using NUnit.Framework;
                     kernel.Rebind<IRevokeListener>().ToConstant(revokingManager);
                     kernel.Rebind<ICacheRevoker>().ToConstant(revokingManager);
                     kernel.Rebind<IMetricsInitializer>().To<MetricsInitializerFake>();
+                    kernel.Rebind<IEventPublisher>().To<SpyEventPublisher>().InSingletonScope();
+
                 });            
                 ResolutionRoot = kernel;
             }

--- a/tests/Gigya.Microdot.Orleans.Hosting.UnitTests/CalculatorServiceTests.cs
+++ b/tests/Gigya.Microdot.Orleans.Hosting.UnitTests/CalculatorServiceTests.cs
@@ -24,10 +24,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using Gigya.Microdot.Fakes;
+using Gigya.Microdot.Hosting.Events;
 using Gigya.Microdot.Interfaces;
+using Gigya.Microdot.Interfaces.Events;
 using Gigya.Microdot.Interfaces.HttpService;
 using Gigya.Microdot.Orleans.Hosting.UnitTests.Microservice.CalculatorService;
 using Gigya.Microdot.ServiceProxy;
@@ -72,7 +73,7 @@ namespace Gigya.Microdot.Orleans.Hosting.UnitTests
             try
             {
 
-                Tester = AssemblyInitialize.ResolutionRoot.GetServiceTester<CalculatorServiceHost>(writeLogToFile:true);
+                Tester = AssemblyInitialize.ResolutionRoot.GetServiceTester<CalculatorServiceHost>(writeLogToFile: true);
                 Service = Tester.GetServiceProxy<ICalculatorService>();
                 ServiceWithCaching = Tester.GetServiceProxyWithCaching<ICalculatorService>();
 
@@ -303,5 +304,28 @@ namespace Gigya.Microdot.Orleans.Hosting.UnitTests
             File.ReadAllText("TestLog.txt").ShouldContain(logMessage);
         }
 
+        [Test]
+        public async Task ShouldPublishEventWithCallParametersDefault()
+        {
+            var sensitive = "sensitive test";
+            var nonsensitive = "nonsensitive Test";
+            var notExists = "notExists Test";
+            var @default = "default Test";
+
+            await Service.LogPram(sensitive, nonsensitive, notExists, @default);
+            (await Service.IsLogPramSucceed(new List<string>{@default, sensitive }, new List<string> { nonsensitive }, new List<string> { notExists })).ShouldBeTrue();
+        }
+
+        [Test]
+        public async Task ShouldPublishEventWithCallParametersMethodNonsensitive()
+        {
+            var sensitive = "sensitive test";
+            var nonsensitive = "nonsensitive Test";
+            var notExists = "notExists Test";
+            var @default = "default Test";
+
+            await Service.LogPram2(sensitive, nonsensitive, notExists, @default);
+            (await Service.IsLogPramSucceed(new List<string> {  sensitive }, new List<string> { nonsensitive , @default }, new List<string> { notExists })).ShouldBeTrue();
+        }
     }
 }

--- a/tests/Gigya.Microdot.Orleans.Hosting.UnitTests/Gigya.Microdot.Orleans.Hosting.UnitTests.csproj
+++ b/tests/Gigya.Microdot.Orleans.Hosting.UnitTests/Gigya.Microdot.Orleans.Hosting.UnitTests.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Properties\orleans.codegen.cs" />
     <Compile Include="SchemaEndpointTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SpyEventPublisher.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/tests/Gigya.Microdot.Orleans.Hosting.UnitTests/Microservice/CalculatorService/CalculatorServiceHost.cs
+++ b/tests/Gigya.Microdot.Orleans.Hosting.UnitTests/Microservice/CalculatorService/CalculatorServiceHost.cs
@@ -48,7 +48,7 @@ namespace Gigya.Microdot.Orleans.Hosting.UnitTests.Microservice.CalculatorServic
             else
                 logBinding.To<ConsoleLog>();
 
-            eventPublisherBinding.To<NullEventPublisher>();
+            eventPublisherBinding.To<SpyEventPublisher>().InSingletonScope();
         }
     }
 

--- a/tests/Gigya.Microdot.Orleans.Hosting.UnitTests/Microservice/CalculatorService/ICalculatorService.cs
+++ b/tests/Gigya.Microdot.Orleans.Hosting.UnitTests/Microservice/CalculatorService/ICalculatorService.cs
@@ -58,10 +58,10 @@ namespace Gigya.Microdot.Orleans.Hosting.UnitTests.Microservice.CalculatorServic
         [Cached] Task<Revocable<int>> GetVersion(string id);
         Task LogData(string message);
         
-        Task LogPram([Sensitive] string sensitive, [NonSensitive] string notSensitive,[Sensitive( DoNotLog = true)]string notExists,string @default );
+        Task LogPram([Sensitive] string sensitive, [NonSensitive] string notSensitive,[Sensitive( Secretive = true)]string notExists,string @default );
 
         [NonSensitive]
-        Task LogPram2([Sensitive] string sensitive, [NonSensitive] string notSensitive, [Sensitive(DoNotLog = true)]string notExists, string @default);
+        Task LogPram2([Sensitive] string sensitive, [NonSensitive] string notSensitive, [Sensitive(Secretive = true)]string notExists, string @default);
 
         Task<bool> IsLogPramSucceed(List<string> sensitives, List<string> NoneSensitives, List<string> NotExists);
     }

--- a/tests/Gigya.Microdot.Orleans.Hosting.UnitTests/Microservice/CalculatorService/ICalculatorService.cs
+++ b/tests/Gigya.Microdot.Orleans.Hosting.UnitTests/Microservice/CalculatorService/ICalculatorService.cs
@@ -21,11 +21,15 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Gigya.Common.Contracts.Attributes;
 using Gigya.Common.Contracts.HttpService;
+using Gigya.Microdot.Hosting.Events;
+using Gigya.ServiceContract.Attributes;
 using Gigya.ServiceContract.HttpService;
 using Newtonsoft.Json.Linq;
+using NUnit.Framework;
 
 namespace Gigya.Microdot.Orleans.Hosting.UnitTests.Microservice.CalculatorService
 {
@@ -53,5 +57,12 @@ namespace Gigya.Microdot.Orleans.Hosting.UnitTests.Microservice.CalculatorServic
         [Cached] Task<int> GetNextNum();
         [Cached] Task<Revocable<int>> GetVersion(string id);
         Task LogData(string message);
+        
+        Task LogPram([Sensitive] string sensitive, [NonSensitive] string notSensitive,[Sensitive( DoNotLog = true)]string notExists,string @default );
+
+        [NonSensitive]
+        Task LogPram2([Sensitive] string sensitive, [NonSensitive] string notSensitive, [Sensitive(DoNotLog = true)]string notExists, string @default);
+
+        Task<bool> IsLogPramSucceed(List<string> sensitives, List<string> NoneSensitives, List<string> NotExists);
     }
 }

--- a/tests/Gigya.Microdot.Orleans.Hosting.UnitTests/SpyEventPublisher.cs
+++ b/tests/Gigya.Microdot.Orleans.Hosting.UnitTests/SpyEventPublisher.cs
@@ -1,0 +1,21 @@
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Gigya.Microdot.Interfaces.Events;
+using NSubstitute;
+
+namespace Gigya.Microdot.Fakes
+{
+    public class SpyEventPublisher : IEventPublisher
+    {
+        static readonly PublishingTasks PublishingTasks = new PublishingTasks { PublishEvent = Task.FromResult(true), PublishAudit = Task.FromResult(true) };
+        public ConcurrentQueue<IEvent> Events = new ConcurrentQueue<IEvent>();
+
+        public PublishingTasks TryPublish(IEvent evt)
+        {
+            evt.Configuration = Substitute.For<IEventConfiguration>();
+            evt.Configuration.ParamTruncateLength = 1000000; 
+          Events.Enqueue(evt);
+            return PublishingTasks;
+        }
+    }
+}


### PR DESCRIPTION
…t with the [NonSensitive] attribute. If it's applied to a whole method, use the [Sensitive] attribute to keep encrypting certain parameters.