### PR TITLE
Improve stack trace readability

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -1,0 +1,243 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Prevent dotnet template engine to parse this file -->
+  <!--/-:cnd:noEmit-->
+  <PropertyGroup>
+    <!-- make MSBuild track this file for incremental builds. -->
+    <!-- ref https://blogs.msdn.microsoft.com/msbuild/2005/09/26/how-to-ensure-changes-to-a-custom-target-file-prompt-a-rebuild/ -->
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <!-- Mark that this target file has been loaded.  -->
+    <IsPaketRestoreTargetsFileLoaded>true</IsPaketRestoreTargetsFileLoaded>
+    <PaketToolsPath>$(MSBuildThisFileDirectory)</PaketToolsPath>
+    <PaketRootPath>$(MSBuildThisFileDirectory)..\</PaketRootPath>
+    <PaketRestoreCacheFile>$(PaketRootPath)paket-files\paket.restore.cached</PaketRestoreCacheFile>
+    <PaketLockFilePath>$(PaketRootPath)paket.lock</PaketLockFilePath>
+    <MonoPath Condition="'$(MonoPath)' == '' And Exists('/Library/Frameworks/Mono.framework/Commands/mono')">/Library/Frameworks/Mono.framework/Commands/mono</MonoPath>
+    <MonoPath Condition="'$(MonoPath)' == ''">mono</MonoPath>
+    <!-- Paket command -->
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketRootPath)paket.exe')">$(PaketRootPath)paket.exe</PaketExePath>
+    <PaketExePath Condition=" '$(PaketExePath)' == '' ">$(PaketToolsPath)paket.exe</PaketExePath>
+    <PaketCommand Condition=" '$(OS)' == 'Windows_NT'">"$(PaketExePath)"</PaketCommand>
+    <PaketCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketExePath)"</PaketCommand>
+    <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' AND Exists('$(PaketRootPath)paket.bootstrapper.exe')">$(PaketRootPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
+    <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
+    <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT'">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
+    <PaketBootStrapperCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
+
+    <!-- Disable automagic references for F# dotnet sdk -->
+    <!-- This will not do anything for other project types -->
+    <!-- see https://github.com/fsharp/fslang-design/blob/master/RFCs/FS-1032-fsharp-in-dotnet-sdk.md -->
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
+  </PropertyGroup>
+
+  <Target Name="PaketRestore" BeforeTargets="_GenerateDotnetCliToolReferenceSpecs;_GenerateProjectRestoreGraphPerFramework;_GenerateRestoreGraphWalkPerFramework;CollectPackageReferences" >
+
+    <!-- Step 1 Check if lockfile is properly restored -->
+    <PropertyGroup>
+      <PaketRestoreRequired>true</PaketRestoreRequired>
+      <NoWarn>$(NoWarn);NU1603</NoWarn>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="Exists('$(PaketRestoreCacheFile)') ">
+      <PaketRestoreCachedHash>$([System.IO.File]::ReadAllText('$(PaketRestoreCacheFile)'))</PaketRestoreCachedHash>
+      <PaketRestoreLockFileHash>$([System.IO.File]::ReadAllText('$(PaketLockFilePath)'))</PaketRestoreLockFileHash>
+      <PaketRestoreRequired>true</PaketRestoreRequired>
+      <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '$(PaketRestoreCachedHash)' ">false</PaketRestoreRequired>
+      <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '' ">true</PaketRestoreRequired>
+    </PropertyGroup>
+
+    <!-- Do a global restore if required -->
+    <Exec Command='$(PaketBootStrapperCommand)' Condition="Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
+    <Exec Command='$(PaketCommand) restore' Condition=" '$(PaketRestoreRequired)' == 'true' " ContinueOnError="false" />
+
+    <!-- Step 2 Detect project specific changes -->
+    <PropertyGroup>
+      <PaketReferencesCachedFilePath>$(MSBuildProjectDirectory)\obj\$(MSBuildProjectFile).paket.references.cached</PaketReferencesCachedFilePath>
+      <!-- MyProject.fsproj.paket.references has the highest precedence -->
+      <PaketOriginalReferencesFilePath>$(MSBuildProjectFullPath).paket.references</PaketOriginalReferencesFilePath>
+      <!-- MyProject.paket.references -->
+      <PaketOriginalReferencesFilePath Condition=" !Exists('$(PaketOriginalReferencesFilePath)')">$(MSBuildProjectDirectory)\$(MSBuildProjectName).paket.references</PaketOriginalReferencesFilePath>
+      <!-- paket.references -->
+      <PaketOriginalReferencesFilePath Condition=" !Exists('$(PaketOriginalReferencesFilePath)')">$(MSBuildProjectDirectory)\paket.references</PaketOriginalReferencesFilePath>
+      <PaketResolvedFilePath>$(MSBuildProjectDirectory)\obj\$(MSBuildProjectFile).$(TargetFramework).paket.resolved</PaketResolvedFilePath>
+      <PaketRestoreRequired>true</PaketRestoreRequired>
+      <PaketRestoreRequiredReason>references-file-or-cache-not-found</PaketRestoreRequiredReason>
+    </PropertyGroup>
+
+    <!-- Step 2 a Detect changes in references file -->
+    <PropertyGroup Condition="Exists('$(PaketOriginalReferencesFilePath)') AND Exists('$(PaketReferencesCachedFilePath)') ">
+      <PaketRestoreCachedHash>$([System.IO.File]::ReadAllText('$(PaketReferencesCachedFilePath)'))</PaketRestoreCachedHash>
+      <PaketRestoreReferencesFileHash>$([System.IO.File]::ReadAllText('$(PaketOriginalReferencesFilePath)'))</PaketRestoreReferencesFileHash>
+      <PaketRestoreRequiredReason>references-file</PaketRestoreRequiredReason>
+      <PaketRestoreRequired Condition=" '$(PaketRestoreReferencesFileHash)' == '$(PaketRestoreCachedHash)' ">false</PaketRestoreRequired>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="!Exists('$(PaketOriginalReferencesFilePath)') AND !Exists('$(PaketReferencesCachedFilePath)') ">
+      <!-- If both don't exist there is nothing to do. -->
+      <PaketRestoreRequired>false</PaketRestoreRequired>
+    </PropertyGroup>
+
+    <!-- Step 2 b detect relevant changes in project file (new targetframework) -->
+    <PropertyGroup Condition=" !Exists('$(PaketResolvedFilePath)') AND '$(TargetFramework)' != '' ">
+      <PaketRestoreRequired>true</PaketRestoreRequired>
+      <PaketRestoreRequiredReason>target-framework '$(TargetFramework)'</PaketRestoreRequiredReason>
+    </PropertyGroup>
+
+    <!-- Step 3 Restore project specific stuff if required -->
+    <Message Condition=" '$(PaketRestoreRequired)' == 'true' " Importance="low" Text="Detected a change ('$(PaketRestoreRequiredReason)') in the project file '$(MSBuildProjectFullPath)', calling paket restore" />
+    <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)"' Condition=" '$(PaketRestoreRequired)' == 'true' " ContinueOnError="false" />
+
+    <!-- This shouldn't actually happen, but just to be sure. -->
+    <Error Condition=" !Exists('$(PaketResolvedFilePath)') AND '$(TargetFramework)' != '' " Text="A paket file for the framework '$(TargetFramework)' is missing. Please delete 'paket-files/paket.restore.cached' and call 'paket restore'." />
+
+    <!-- Step 4 forward all msbuild properties (PackageReference, DotNetCliToolReference) to msbuild -->
+    <ReadLinesFromFile Condition="Exists('$(PaketResolvedFilePath)')" File="$(PaketResolvedFilePath)" >
+      <Output TaskParameter="Lines" ItemName="PaketReferencesFileLines"/>
+    </ReadLinesFromFile>
+
+    <ItemGroup Condition=" Exists('$(PaketResolvedFilePath)') AND '@(PaketReferencesFileLines)' != '' " >
+      <PaketReferencesFileLinesInfo Include="@(PaketReferencesFileLines)" >
+        <PackageName>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[0])</PackageName>
+        <PackageVersion>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[1])</PackageVersion>
+      </PaketReferencesFileLinesInfo>
+      <PackageReference Include="%(PaketReferencesFileLinesInfo.PackageName)">
+        <Version>%(PaketReferencesFileLinesInfo.PackageVersion)</Version>
+      </PackageReference>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <PaketCliToolFilePath>$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).paket.clitools</PaketCliToolFilePath>
+    </PropertyGroup>
+
+    <ReadLinesFromFile File="$(PaketCliToolFilePath)" >
+      <Output TaskParameter="Lines" ItemName="PaketCliToolFileLines"/>
+    </ReadLinesFromFile>
+
+    <ItemGroup Condition=" '@(PaketCliToolFileLines)' != '' " >
+      <PaketCliToolFileLinesInfo Include="@(PaketCliToolFileLines)" >
+        <PackageName>$([System.String]::Copy('%(PaketCliToolFileLines.Identity)').Split(',')[0])</PackageName>
+        <PackageVersion>$([System.String]::Copy('%(PaketCliToolFileLines.Identity)').Split(',')[1])</PackageVersion>
+      </PaketCliToolFileLinesInfo>
+      <DotNetCliToolReference Include="%(PaketCliToolFileLinesInfo.PackageName)">
+        <Version>%(PaketCliToolFileLinesInfo.PackageVersion)</Version>
+      </DotNetCliToolReference>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <RestoreConfigFile>$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).NuGet.Config</RestoreConfigFile>
+    </PropertyGroup>
+
+  </Target>
+
+  <Target Name="PaketDisableDirectPack" AfterTargets="_IntermediatePack" BeforeTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).references')" >
+    <PropertyGroup>
+      <ContinuePackingAfterGeneratingNuspec>false</ContinuePackingAfterGeneratingNuspec>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="PaketOverrideNuspec" AfterTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).references')" >
+    <PropertyGroup>
+      <PaketProjectFile>$(MSBuildProjectDirectory)/$(MSBuildProjectFile)</PaketProjectFile>
+      <ContinuePackingAfterGeneratingNuspec>true</ContinuePackingAfterGeneratingNuspec>
+      <UseNewPack>false</UseNewPack>
+      <UseNewPack Condition=" '$(NuGetToolVersion)' != '4.0.0' ">true</UseNewPack>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_NuspecFiles Include="$(BaseIntermediateOutputPath)*.nuspec"/>
+    </ItemGroup>
+
+    <Exec Command='$(PaketCommand) fix-nuspecs files "@(_NuspecFiles)" project-file "$(PaketProjectFile)" ' Condition="@(_NuspecFiles) != ''" />
+
+    <ConvertToAbsolutePath Condition="@(_NuspecFiles) != ''" Paths="@(_NuspecFiles)">
+      <Output TaskParameter="AbsolutePaths" PropertyName="NuspecFileAbsolutePath" />
+    </ConvertToAbsolutePath>
+
+    <!-- Call Pack -->
+    <PackTask Condition="$(UseNewPack)"
+              PackItem="$(PackProjectInputFile)"
+              PackageFiles="@(_PackageFiles)"
+              PackageFilesToExclude="@(_PackageFilesToExclude)"
+              PackageVersion="$(PackageVersion)"
+              PackageId="$(PackageId)"
+              Title="$(Title)"
+              Authors="$(Authors)"
+              Description="$(Description)"
+              Copyright="$(Copyright)"
+              RequireLicenseAcceptance="$(PackageRequireLicenseAcceptance)"
+              LicenseUrl="$(PackageLicenseUrl)"
+              ProjectUrl="$(PackageProjectUrl)"
+              IconUrl="$(PackageIconUrl)"
+              ReleaseNotes="$(PackageReleaseNotes)"
+              Tags="$(PackageTags)"
+              DevelopmentDependency="$(DevelopmentDependency)"
+              BuildOutputInPackage="@(_BuildOutputInPackage)"
+              TargetPathsToSymbols="@(_TargetPathsToSymbols)"
+              TargetFrameworks="@(_TargetFrameworks)"
+              AssemblyName="$(AssemblyName)"
+              PackageOutputPath="$(PackageOutputAbsolutePath)"
+              IncludeSymbols="$(IncludeSymbols)"
+              IncludeSource="$(IncludeSource)"
+              PackageTypes="$(PackageType)"
+              IsTool="$(IsTool)"
+              RepositoryUrl="$(RepositoryUrl)"
+              RepositoryType="$(RepositoryType)"
+              SourceFiles="@(_SourceFiles->Distinct())"
+              NoPackageAnalysis="$(NoPackageAnalysis)"
+              MinClientVersion="$(MinClientVersion)"
+              Serviceable="$(Serviceable)"
+              FrameworkAssemblyReferences="@(_FrameworkAssemblyReferences)"
+              ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
+              NuspecOutputPath="$(BaseIntermediateOutputPath)"
+              IncludeBuildOutput="$(IncludeBuildOutput)"
+              BuildOutputFolder="$(BuildOutputTargetFolder)"
+              ContentTargetFolders="$(ContentTargetFolders)"
+              RestoreOutputPath="$(RestoreOutputAbsolutePath)"
+              NuspecFile="$(NuspecFileAbsolutePath)"
+              NuspecBasePath="$(NuspecBasePath)"
+              NuspecProperties="$(NuspecProperties)"/>
+
+    <PackTask Condition="! $(UseNewPack)"
+              PackItem="$(PackProjectInputFile)"
+              PackageFiles="@(_PackageFiles)"
+              PackageFilesToExclude="@(_PackageFilesToExclude)"
+              PackageVersion="$(PackageVersion)"
+              PackageId="$(PackageId)"
+              Title="$(Title)"
+              Authors="$(Authors)"
+              Description="$(Description)"
+              Copyright="$(Copyright)"
+              RequireLicenseAcceptance="$(PackageRequireLicenseAcceptance)"
+              LicenseUrl="$(PackageLicenseUrl)"
+              ProjectUrl="$(PackageProjectUrl)"
+              IconUrl="$(PackageIconUrl)"
+              ReleaseNotes="$(PackageReleaseNotes)"
+              Tags="$(PackageTags)"
+              TargetPathsToAssemblies="@(_TargetPathsToAssemblies->'%(FinalOutputPath)')"
+              TargetPathsToSymbols="@(_TargetPathsToSymbols)"
+              TargetFrameworks="@(_TargetFrameworks)"
+              AssemblyName="$(AssemblyName)"
+              PackageOutputPath="$(PackageOutputAbsolutePath)"
+              IncludeSymbols="$(IncludeSymbols)"
+              IncludeSource="$(IncludeSource)"
+              PackageTypes="$(PackageType)"
+              IsTool="$(IsTool)"
+              RepositoryUrl="$(RepositoryUrl)"
+              RepositoryType="$(RepositoryType)"
+              SourceFiles="@(_SourceFiles->Distinct())"
+              NoPackageAnalysis="$(NoPackageAnalysis)"
+              MinClientVersion="$(MinClientVersion)"
+              Serviceable="$(Serviceable)"
+              AssemblyReferences="@(_References)"
+              ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
+              NuspecOutputPath="$(BaseIntermediateOutputPath)"
+              IncludeBuildOutput="$(IncludeBuildOutput)"
+              BuildOutputFolder="$(BuildOutputTargetFolder)"
+              ContentTargetFolders="$(ContentTargetFolders)"
+              RestoreOutputPath="$(RestoreOutputAbsolutePath)"
+              NuspecFile="$(NuspecFileAbsolutePath)"
+              NuspecBasePath="$(NuspecBasePath)"
+              NuspecProperties="$(NuspecProperties)"/>
+  </Target>
+  <!--/+:cnd:noEmit-->
+</Project>

--- a/Gigya.Microdot.Hosting/HttpService/HttpServiceListener.cs
+++ b/Gigya.Microdot.Hosting/HttpService/HttpServiceListener.cs
@@ -80,6 +80,7 @@ namespace Gigya.Microdot.Hosting.HttpService
         private IEventPublisher<ServiceCallEvent> EventPublisher { get; }
         private IEnumerable<ICustomEndpoint> CustomEndpoints { get; }
         private IEnvironmentVariableProvider EnvironmentVariableProvider { get; }
+        private JsonExceptionSerializer ExceptionSerializer { get; }
 
         private readonly Timer _serializationTime;
         private readonly Timer _deserializationTime;
@@ -92,7 +93,8 @@ namespace Gigya.Microdot.Hosting.HttpService
 
         public HttpServiceListener(IActivator activator, IWorker worker, IServiceEndPointDefinition serviceEndPointDefinition,
                                    ICertificateLocator certificateLocator, ILog log, IEventPublisher<ServiceCallEvent> eventPublisher,
-                                   IEnumerable<ICustomEndpoint> customEndpoints, IEnvironmentVariableProvider environmentVariableProvider)
+                                   IEnumerable<ICustomEndpoint> customEndpoints, IEnvironmentVariableProvider environmentVariableProvider,
+                                   JsonExceptionSerializer exceptionSerializer)
         {
             ServiceEndPointDefinition = serviceEndPointDefinition;
             Worker = worker;
@@ -101,6 +103,7 @@ namespace Gigya.Microdot.Hosting.HttpService
             EventPublisher = eventPublisher;
             CustomEndpoints = customEndpoints.ToArray();
             EnvironmentVariableProvider = environmentVariableProvider;
+            ExceptionSerializer = exceptionSerializer;
 
             if (serviceEndPointDefinition.UseSecureChannel)
                 ServerRootCertHash = certificateLocator.GetCertificate("Service").GetHashOfRootCertificate();
@@ -202,7 +205,7 @@ namespace Gigya.Microdot.Hosting.HttpService
                 catch (Exception e)
                 {
                     var ex = GetRelevantException(e);
-                    await TryWriteResponse(context, JsonExceptionSerializer.Serialize(ex), GetExceptionStatusCode(ex));
+                    await TryWriteResponse(context, ExceptionSerializer.Serialize(ex), GetExceptionStatusCode(ex));
                     return;
                 }
 
@@ -216,6 +219,7 @@ namespace Gigya.Microdot.Hosting.HttpService
                     Exception actualException = null;
                     string methodName = null;
                     // Initialize with empty object for protocol backwards-compatibility.
+
                     var requestData = new HttpServiceRequest { TracingData = new TracingData() };
                     
                     ServiceMethod serviceMethod = null;
@@ -253,7 +257,7 @@ namespace Gigya.Microdot.Hosting.HttpService
                         _failureCounter.Increment();
                         ex = GetRelevantException(e);
 
-                        string json = _serializationTime.Time(() => JsonExceptionSerializer.Serialize(ex));
+                        string json = _serializationTime.Time(() => ExceptionSerializer.Serialize(ex));
                         await TryWriteResponse(context, json, GetExceptionStatusCode(ex));
                     }
                     finally

--- a/Gigya.Microdot.Interfaces/Events/IEvent.cs
+++ b/Gigya.Microdot.Interfaces/Events/IEvent.cs
@@ -22,6 +22,7 @@
 
 using System;
 using Gigya.Microdot.Interfaces.Configuration;
+using Gigya.Microdot.Interfaces.Logging;
 
 namespace Gigya.Microdot.Interfaces.Events
 {
@@ -36,5 +37,7 @@ namespace Gigya.Microdot.Interfaces.Events
         IEventConfiguration Configuration { get; set; }
 
         IEnvironmentVariableProvider EnvironmentVariableProvider { get; set; }
+
+        IStackTraceEnhancer StackTraceEnhancer { get; set; }
     }
 }

--- a/Gigya.Microdot.Interfaces/Gigya.Microdot.Interfaces.csproj
+++ b/Gigya.Microdot.Interfaces/Gigya.Microdot.Interfaces.csproj
@@ -60,6 +60,7 @@
     <Compile Include="IMetricsInitializer.cs" />
     <Compile Include="IMetricsSettings.cs" />
     <Compile Include="Logging\ILog.cs" />
+    <Compile Include="Logging\IStackTraceEnhancer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SystemWrappers\IDateTime.cs" />
     <Compile Include="SystemWrappers\IDirectories.cs" />
@@ -70,6 +71,12 @@
       <SubType>Designer</SubType>
     </None>
     <None Include="paket.template" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Gigya.ServiceContract\Gigya.ServiceContract.csproj">
+      <Project>{DB6D3561-835E-40D5-B9D4-83951CF426DF}</Project>
+      <Name>Gigya.ServiceContract</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Gigya.Microdot.Interfaces/Logging/IStackTraceEnhancer.cs
+++ b/Gigya.Microdot.Interfaces/Logging/IStackTraceEnhancer.cs
@@ -1,0 +1,10 @@
+﻿using Gigya.Common.Contracts.Exceptions;
+
+namespace Gigya.Microdot.Interfaces.Logging
+{
+    public interface IStackTraceEnhancer
+    {
+        string Clean(string stackTrace);
+        string AddBreadcrumb(SerializableException exception);
+    }
+}

--- a/Gigya.Microdot.Logging.NLog/LogEventPublisher.cs
+++ b/Gigya.Microdot.Logging.NLog/LogEventPublisher.cs
@@ -13,6 +13,7 @@ namespace Gigya.Microdot.Logging.NLog
     {
         private ILog Log { get; }
         private IEnvironmentVariableProvider EnvProvider { get; }
+        private IStackTraceEnhancer StackTraceEnhancer { get; }
 
         private PublishingTasks PublishingTasks { get; } = new PublishingTasks
         {
@@ -20,16 +21,18 @@ namespace Gigya.Microdot.Logging.NLog
             PublishAudit = Task.FromResult(false)
         };
 
-        public LogEventPublisher(ILog log, IEnvironmentVariableProvider envProvider)
+        public LogEventPublisher(ILog log, IEnvironmentVariableProvider envProvider, IStackTraceEnhancer stackTraceEnhancer)
         {
             Log = log;
             EnvProvider = envProvider;
+            StackTraceEnhancer = stackTraceEnhancer;
         }
 
         public PublishingTasks TryPublish(IEvent evt)
         {
             evt.Configuration = new EventConfig();
             evt.EnvironmentVariableProvider = EnvProvider;
+            evt.StackTraceEnhancer = StackTraceEnhancer;
             Log.Debug(l => l("Tracing event", unencryptedTags: evt));
             return PublishingTasks;
         }

--- a/Gigya.Microdot.ServiceProxy/ServiceProxyProvider.cs
+++ b/Gigya.Microdot.ServiceProxy/ServiceProxyProvider.cs
@@ -128,6 +128,7 @@ namespace Gigya.Microdot.ServiceProxy
         private ILog Log { get; }
         private ServiceDiscoveryConfig GetConfig() => GetDiscoveryConfig().Services[ServiceName];
         private Func<DiscoveryConfig> GetDiscoveryConfig { get; }
+        private JsonExceptionSerializer ExceptionSerializer { get; }
 
         private IEventPublisher<ClientCallEvent> EventPublisher { get; }
 
@@ -141,7 +142,8 @@ namespace Gigya.Microdot.ServiceProxy
             ICertificateLocator certificateLocator,
             ILog log,
             Func<string, ReachabilityChecker, IServiceDiscovery> serviceDiscoveryFactory,
-            Func<DiscoveryConfig> getConfig)
+            Func<DiscoveryConfig> getConfig,
+            JsonExceptionSerializer exceptionSerializer)
         {
             EventPublisher = eventPublisher;
             CertificateLocator = certificateLocator;
@@ -150,6 +152,7 @@ namespace Gigya.Microdot.ServiceProxy
 
             ServiceName = serviceName;
             GetDiscoveryConfig = getConfig;
+            ExceptionSerializer = exceptionSerializer;
 
             var metricsContext = Metric.Context(METRICS_CONTEXT_NAME).Context(ServiceName);
             _serializationTime = metricsContext.Timer("Serialization", Unit.Calls);
@@ -439,7 +442,7 @@ namespace Gigya.Microdot.ServiceProxy
 
                             try
                             {
-                                remoteException = _deserializationTime.Time(() => JsonExceptionSerializer.Deserialize(responseContent));
+                                remoteException = _deserializationTime.Time(() => ExceptionSerializer.Deserialize(responseContent));
                             }
                             catch(Exception ex)
                             {

--- a/Gigya.Microdot.SharedLogic/Events/EventConsts.cs
+++ b/Gigya.Microdot.SharedLogic/Events/EventConsts.cs
@@ -53,6 +53,7 @@ namespace Gigya.Microdot.SharedLogic.Events
         public const string exOneWordInnerMessages = "ex.inner.oneWordMessages";
         public const string exInnerType = "ex.inner.type";
         public const string exStackTrace = "ex.stackTrace";
+        public const string exStackTraceUnclean = "ex.stackTraceUnclean";
         public const string exType = "ex.type";
         public const string tags = "tags";
 

--- a/Gigya.Microdot.SharedLogic/Exceptions/ExceptionHierarchySerializationBinder.cs
+++ b/Gigya.Microdot.SharedLogic/Exceptions/ExceptionHierarchySerializationBinder.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Gigya.Microdot.SharedLogic.Exceptions
+{
+    internal class ExceptionHierarchySerializationBinder : DefaultSerializationBinder
+    {
+        public override Type BindToType(string assemblyName, string typeName)
+        {
+            var assemblyNames = assemblyName.Split(':');
+            var typeNames = typeName.Split(':');
+            var type = assemblyNames.Zip(typeNames, TryBindToType).FirstOrDefault(t => t != null);
+
+            return type ?? base.BindToType(typeof(Exception).Assembly.GetName().Name, typeof(Exception).FullName);
+        }
+
+        private Type TryBindToType(string assemblyName, string typeName)
+        {
+            try
+            {
+                return base.BindToType(assemblyName, typeName);
+            }
+            catch (JsonSerializationException)
+            {
+                return null;
+            }
+        }
+
+        public override void BindToName(Type serializedType, out string assemblyName, out string typeName)
+        {
+            if (serializedType.IsSubclassOf(typeof(Exception)))
+            {
+                var inheritanceHierarchy = GetInheritanceHierarchy(serializedType)
+                    .Where(t => t.IsAbstract == false && t != typeof(object) && t != typeof(Exception))
+                    .ToArray();
+
+                typeName = string.Join(":", inheritanceHierarchy.Select(t => t.FullName));
+                assemblyName = string.Join(":", inheritanceHierarchy.Select(t => t.Assembly.GetName().Name));
+            }
+            else
+            {
+                base.BindToName(serializedType, out assemblyName, out typeName);
+            }
+        }
+
+        private static IEnumerable<Type> GetInheritanceHierarchy(Type type)
+        {
+            for (var current = type; current != null; current = current.BaseType)
+                yield return current;
+        }
+    }
+}

--- a/Gigya.Microdot.SharedLogic/Exceptions/JsonExceptionSerializer.cs
+++ b/Gigya.Microdot.SharedLogic/Exceptions/JsonExceptionSerializer.cs
@@ -21,23 +21,19 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
 using Gigya.Common.Contracts.Exceptions;
-using Gigya.Microdot.SharedLogic.Utils;
+using Gigya.Microdot.Interfaces.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Newtonsoft.Json.Serialization;
 
 namespace Gigya.Microdot.SharedLogic.Exceptions
 {
 	/// <summary>
 	/// Serializes and deserializes exceptions into JSON, with inheritance hiearchy tolerance.
 	/// </summary>
-	public static class JsonExceptionSerializer
+	public class JsonExceptionSerializer
 	{
-		private static readonly JsonSerializerSettings Settings = new JsonSerializerSettings
+        private static readonly JsonSerializerSettings Settings = new JsonSerializerSettings
 		{
 			TypeNameHandling = TypeNameHandling.All,
 			Binder = new ExceptionHierarchySerializationBinder(),
@@ -46,108 +42,67 @@ namespace Gigya.Microdot.SharedLogic.Exceptions
             Converters = { new StripHttpRequestExceptionConverter() }
         };
 
-		/// <summary>
-		/// Serializes and exception into JSON, and embeds the entire inheritance hiearchy of the exception into the $type property.
-		/// </summary>
-		/// <param name="ex">The exception to serialize.</param>
-		/// <returns>The JSON into which the exception was serialized.</returns>
-		/// <exception cref="Newtonsoft.Json.JsonSerializationException">Thrown when the exception failed to serialize.</exception>
-		public static string Serialize(Exception ex)
-		{
-			return JsonConvert.SerializeObject(ex, typeof(Exception), Settings);
-		}
+	    private static readonly JsonSerializer Serializer = new JsonSerializer
+	    {
+	        TypeNameHandling = TypeNameHandling.All,
+	        Binder = new ExceptionHierarchySerializationBinder(),
+	        Formatting = Formatting.Indented,
+	        DateParseHandling = DateParseHandling.DateTimeOffset,
+	        Converters = { new StripHttpRequestExceptionConverter() }
+	    };
 
-		/// <summary>
-		/// Deserializes an exception from JSON, and uses the inheritance hiearchy embedded into the $type property in order to fall back to the
-		/// first type up the hiearchy that successfully deserializes. 
-		/// </summary>
-		/// <param name="json">The JSON to deserialize.</param>
-		/// <returns>The deserialized exception.</returns>
-		/// <exception cref="Newtonsoft.Json.JsonSerializationException">Thrown when the exception failed to deserialize.</exception>
-		public static Exception Deserialize(string json)
-		{
-			var ex = JsonConvert.DeserializeObject<Exception>(json, Settings);
+	    private IStackTraceEnhancer StackTraceEnhancer { get; }
+        
+        public JsonExceptionSerializer(IStackTraceEnhancer stackTraceEnhancer)
+	    {
+	        StackTraceEnhancer = stackTraceEnhancer;
+	    }
 
-			if (ex == null)
-				throw new JsonSerializationException("Failed to deserialize exception.");
+	    /// <summary>
+	    /// Deserializes an exception from JSON, and uses the inheritance hiearchy embedded into the $type property in order to fall back to the
+	    /// first type up the hiearchy that successfully deserializes. 
+	    /// </summary>
+	    /// <param name="json">The JSON to deserialize.</param>
+	    /// <returns>The deserialized exception.</returns>
+	    /// <exception cref="Newtonsoft.Json.JsonSerializationException">Thrown when the exception failed to deserialize.</exception>
+	    public Exception Deserialize(string json)
+	    {
+	        var ex = JsonConvert.DeserializeObject<Exception>(json, Settings);
 
-			return ex;
-		}
-	}
+	        if (ex == null)
+	            throw new JsonSerializationException("Failed to deserialize exception.");
 
-	internal class ExceptionHierarchySerializationBinder : DefaultSerializationBinder
-	{
-		public override Type BindToType(string assemblyName, string typeName)
-		{
-			var assemblyNames = assemblyName.Split(':');
-			var typeNames = typeName.Split(':');
-			var type = assemblyNames.Zip(typeNames, TryBindToType).FirstOrDefault(t => t != null);
+	        return ex;
+	    }
 
-			return type ?? base.BindToType(typeof(Exception).Assembly.GetName().Name, typeof(Exception).FullName);
-		}
 
-		private Type TryBindToType(string assemblyName, string typeName)
-		{
-			try
-			{
-				return base.BindToType(assemblyName, typeName);
-			}
-			catch (JsonSerializationException)
-			{
-				return null;
-			}
-		}
-
-		public override void BindToName(Type serializedType, out string assemblyName, out string typeName)
-		{
-			if (serializedType.IsSubclassOf(typeof(Exception)))
-			{
-				var inheritanceHierarchy = GetInheritanceHierarchy(serializedType)
-					.Where(t => t.IsAbstract == false && t != typeof(object) && t != typeof(Exception))
-					.ToArray();
-
-				typeName = string.Join(":", inheritanceHierarchy.Select(t => t.FullName));
-				assemblyName = string.Join(":", inheritanceHierarchy.Select(t => t.Assembly.GetName().Name));
-			}
-			else
-			{
-				base.BindToName(serializedType, out assemblyName, out typeName);
-			}
-		}
-
-        private static IEnumerable<Type> GetInheritanceHierarchy(Type type)
+        /// <summary>
+        /// Serializes and exception into JSON, and embeds the entire inheritance hiearchy of the exception into the $type property.
+        /// </summary>
+        /// <param name="ex">The exception to serialize.</param>
+        /// <returns>The JSON into which the exception was serialized.</returns>
+        /// <exception cref="Newtonsoft.Json.JsonSerializationException">Thrown when the exception failed to serialize.</exception>
+        public string Serialize(Exception ex)
         {
-            for (var current = type; current != null; current = current.BaseType)
-                yield return current;
-        }
-    }
+            var outerStackTrace = ex.StackTrace;
 
+            if (ex is SerializableException serializableEx)
+                outerStackTrace = StackTraceEnhancer.AddBreadcrumb(serializableEx);
 
+            var exception = JObject.FromObject(ex, Serializer);
+            exception["StackTraceString"] = outerStackTrace;
 
-    internal class StripHttpRequestExceptionConverter : JsonConverter
-    {
-        public override bool CanConvert(Type objectType)
-        {
-            return objectType == typeof(HttpRequestException);
-        }
+            var current = exception;
 
+            while (current != null)
+            {
+                if (current.Property("StackTraceString") is JProperty stackTrace && stackTrace.Value.Type != JTokenType.Null)
+                    stackTrace.Value = StackTraceEnhancer.Clean(stackTrace.Value.Value<string>());
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-        {
-            var httpException = (HttpRequestException)value;
+                current = current["InnerException"] is JObject inner ? inner : null;
+            }
 
-            var innerException = httpException?.InnerException ??
-                new EnvironmentException("[HttpRequestException] " + httpException?.RawMessage(),
-                unencrypted: new Tags { { "originalStackTrace", httpException?.StackTrace } });
-            
-            JObject.FromObject(innerException, serializer).WriteTo(writer);
-        }
-
-
-        public override bool CanRead => false;
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-        {
-            throw new NotImplementedException();
-        }
+			return JsonConvert.SerializeObject(exception, Settings);
+		}
     }
 }

--- a/Gigya.Microdot.SharedLogic/Exceptions/StackTraceEnhancer.cs
+++ b/Gigya.Microdot.SharedLogic/Exceptions/StackTraceEnhancer.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Gigya.Common.Contracts.Exceptions;
+using Gigya.Microdot.Interfaces.Configuration;
+using Gigya.Microdot.Interfaces.Logging;
+using Gigya.ServiceContract.Exceptions;
+
+namespace Gigya.Microdot.SharedLogic.Exceptions
+{
+    public class StackTraceEnhancer : IStackTraceEnhancer
+    {
+        private Func<StackTraceCleanerSettings> GetConfig { get; }
+        private IEnvironmentVariableProvider EnvironmentVariableProvider { get; }
+
+        public StackTraceEnhancer(Func<StackTraceCleanerSettings> getConfig, IEnvironmentVariableProvider environmentVariableProvider)
+        {
+            GetConfig = getConfig;
+            EnvironmentVariableProvider = environmentVariableProvider;
+        }
+
+        public string AddBreadcrumb(SerializableException exception)
+        {
+            var breadcrumb = new Breadcrumb
+            {
+                ServiceName = CurrentApplicationInfo.Name,
+                ServiceVersion = CurrentApplicationInfo.Version.ToString(),
+                HostName = CurrentApplicationInfo.HostName,
+                DataCenter = EnvironmentVariableProvider.DataCenter,
+                DeploymentEnvironment = EnvironmentVariableProvider.DeploymentEnvironment
+            };
+
+            exception.AddBreadcrumb(breadcrumb);
+
+            return $"--- End of stack trace from {breadcrumb} ---\r\n{exception.StackTrace}";
+        }
+
+        public string Clean(string stackTrace)
+        {
+            if (string.IsNullOrEmpty(stackTrace))
+                return stackTrace;
+
+            var replacements = GetConfig().RegexReplacements.Values.ToArray();
+            var frames = stackTrace
+                .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                .Where(f => f.StartsWith("   at System.Runtime") == false && f != "--- End of stack trace from previous location where exception was thrown ---")
+                .Select(f => ApplyRegexs(f, replacements));
+
+            return string.Join("\r\n", frames);
+        }
+
+        private string ApplyRegexs(string frame, RegexReplace[] replacements)
+        {
+            string updatedFrame = frame;
+
+            foreach (var regexReplace in replacements)
+                updatedFrame = Regex.Replace(updatedFrame, regexReplace.Pattern, regexReplace.Replacement);
+
+            return updatedFrame;
+        }
+    }
+
+    public class StackTraceCleanerSettings : IConfigObject
+    {
+        public Dictionary<string, RegexReplace> RegexReplacements { get; set; } = new Dictionary<string, RegexReplace>();
+    }
+
+    public class RegexReplace
+    {
+        public string Pattern { get; set; }
+        public string Replacement { get; set; }
+    }
+}

--- a/Gigya.Microdot.SharedLogic/Exceptions/StripHttpRequestExceptionConverter.cs
+++ b/Gigya.Microdot.SharedLogic/Exceptions/StripHttpRequestExceptionConverter.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Net.Http;
+using Gigya.Common.Contracts.Exceptions;
+using Gigya.Microdot.SharedLogic.Utils;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Gigya.Microdot.SharedLogic.Exceptions
+{
+    internal class StripHttpRequestExceptionConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(HttpRequestException);
+        }
+
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var httpException = (HttpRequestException)value;
+
+            var innerException = httpException?.InnerException ??
+                                 new EnvironmentException("[HttpRequestException] " + httpException?.RawMessage(),
+                                     unencrypted: new Tags { { "originalStackTrace", httpException?.StackTrace } });
+            
+            JObject.FromObject(innerException, serializer).WriteTo(writer);
+        }
+
+
+        public override bool CanRead => false;
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Gigya.Microdot.SharedLogic/Gigya.Microdot.SharedLogic.csproj
+++ b/Gigya.Microdot.SharedLogic/Gigya.Microdot.SharedLogic.csproj
@@ -46,6 +46,9 @@
     <Compile Include="ApplicationDirectoryProvider.cs" />
     <Compile Include="AssemblyProvider.cs" />
     <Compile Include="Events\Param.cs" />
+    <Compile Include="Exceptions\ExceptionHierarchySerializationBinder.cs" />
+    <Compile Include="Exceptions\StackTraceEnhancer.cs" />
+    <Compile Include="Exceptions\StripHttpRequestExceptionConverter.cs" />
     <Compile Include="Logging\LogBase.cs" />
     <Compile Include="Monitor\AggregatingHealthStatus.cs" />
     <Compile Include="Monitor\IHealthMonitor.cs" />

--- a/Gigya.ServiceContract/Exceptions/Breadcrumb.cs
+++ b/Gigya.ServiceContract/Exceptions/Breadcrumb.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Gigya.ServiceContract.Exceptions
+{
+    [Serializable]
+    public class Breadcrumb
+    {
+        public string ServiceName { get; set; }
+        public string ServiceVersion { get; set; }
+        public string HostName { get; set; }
+        public string DataCenter { get; set; }
+        public string DeploymentEnvironment { get; set; }
+
+        public override string ToString()
+        {
+            return $"{ServiceName} v{ServiceVersion} on {HostName} in {DataCenter}-{DeploymentEnvironment}";
+        }
+    }
+}

--- a/Gigya.ServiceContract/Gigya.ServiceContract.csproj
+++ b/Gigya.ServiceContract/Gigya.ServiceContract.csproj
@@ -42,6 +42,7 @@
     <Compile Include="Attributes\EventAttrubute.cs" />
     <Compile Include="Attributes\HttpServiceAttribute.cs" />
     <Compile Include="Attributes\PublicEndpointAttribute.cs" />
+    <Compile Include="Exceptions\Breadcrumb.cs" />
     <Compile Include="Exceptions\EnvironmentException.cs" />
     <Compile Include="Exceptions\ProgrammaticException.cs" />
     <Compile Include="Exceptions\RemoteServiceException.cs" />

--- a/Gigya.ServiceContract/Properties/AssemblyInfo.cs
+++ b/Gigya.ServiceContract/Properties/AssemblyInfo.cs
@@ -52,3 +52,5 @@ using System.Runtime.InteropServices;
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 [assembly: CLSCompliant(false)]
+
+[assembly: InternalsVisibleTo("Gigya.Microdot.SharedLogic")] 

--- a/tests/Gigya.Microdot.UnitTests/ExceptionExtensions.cs
+++ b/tests/Gigya.Microdot.UnitTests/ExceptionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace Gigya.Microdot.UnitTests
 {
@@ -14,6 +15,26 @@ namespace Gigya.Microdot.UnitTests
             {
                 return ex;
             }
+        }
+
+        public static T ThrowAndCatchAsync<T>(this T exception) where T : Exception
+        {
+            async Task AsyncThrow()
+            {
+                await Task.FromResult(0);
+                throw exception;
+            }
+
+            try
+            {
+                AsyncThrow().GetAwaiter().GetResult();
+            }
+            catch (T ex)
+            {
+                return ex;
+            }
+
+            return null;
         }
     }
 }

--- a/tests/Gigya.Microdot.UnitTests/ServiceListenerTests/HttpServiceListenerTests.cs
+++ b/tests/Gigya.Microdot.UnitTests/ServiceListenerTests/HttpServiceListenerTests.cs
@@ -38,6 +38,7 @@ namespace Gigya.Microdot.UnitTests.ServiceListenerTests
 
         private TestingHost<IDemoService> _testinghost;
         private Task _stopTask;
+        private JsonExceptionSerializer _exceptionSerializer;
 
 
         [SetUp]
@@ -45,6 +46,7 @@ namespace Gigya.Microdot.UnitTests.ServiceListenerTests
         {
             var kernel = new TestingKernel<ConsoleLog>();
             _insecureClient = kernel.Get<IDemoService>();
+            _exceptionSerializer = kernel.Get<JsonExceptionSerializer>();
 
             Metric.ShutdownContext("Service");
             TracingContext.SetUpStorage();
@@ -84,7 +86,7 @@ namespace Gigya.Microdot.UnitTests.ServiceListenerTests
             var request = await GetRequestFor<IDemoService>(p => p.DoSomething());
 
             var responseJson = await (await new HttpClient().SendAsync(request)).Content.ReadAsStringAsync();
-            var responseException = JsonExceptionSerializer.Deserialize(responseJson);
+            var responseException = _exceptionSerializer.Deserialize(responseJson);
             responseException.ShouldBeOfType<UnhandledException>();
         }
 
@@ -98,7 +100,7 @@ namespace Gigya.Microdot.UnitTests.ServiceListenerTests
             var request = await GetRequestFor<IDemoService>(p => p.DoSomething());
 
             var responseJson = await (await new HttpClient().SendAsync(request)).Content.ReadAsStringAsync();
-            var responseException = JsonExceptionSerializer.Deserialize(responseJson);
+            var responseException = _exceptionSerializer.Deserialize(responseJson);
             responseException.ShouldBeOfType(exceptionType);
         }
 

--- a/tests/Gigya.Microdot.UnitTests/ServiceProxyTests/AbstractServiceProxyTest.cs
+++ b/tests/Gigya.Microdot.UnitTests/ServiceProxyTests/AbstractServiceProxyTest.cs
@@ -5,6 +5,7 @@ using System.Runtime.Remoting.Messaging;
 using Gigya.Microdot.Fakes;
 using Gigya.Microdot.ServiceProxy;
 using Gigya.Microdot.SharedLogic.Events;
+using Gigya.Microdot.SharedLogic.Exceptions;
 using Gigya.Microdot.Testing;
 
 using Metrics;
@@ -23,6 +24,7 @@ namespace Gigya.Microdot.UnitTests.ServiceProxyTests
         internal const string SERVICE_NAME = "Demonstration";
         protected TestingKernel<ConsoleLog> unitTesting;
         protected Dictionary<string, string> MockConfig { get; } = new Dictionary<string, string>();
+        protected JsonExceptionSerializer ExceptionSerializer { get; set; }
 
         [SetUp]
         public virtual void SetUp()
@@ -32,6 +34,7 @@ namespace Gigya.Microdot.UnitTests.ServiceProxyTests
             unitTesting = new TestingKernel<ConsoleLog>(mockConfig: MockConfig);
             Metric.ShutdownContext(ServiceProxyProvider.METRICS_CONTEXT_NAME);
             TracingContext.SetRequestID("1");
+            ExceptionSerializer = unitTesting.Get<JsonExceptionSerializer>();
         }
 
 

--- a/tests/Gigya.Microdot.UnitTests/ServiceProxyTests/BehaviorTests.cs
+++ b/tests/Gigya.Microdot.UnitTests/ServiceProxyTests/BehaviorTests.cs
@@ -4,18 +4,17 @@ using System.Net;
 using System.Net.Http;
 using System.Runtime.Remoting.Messaging;
 using System.Threading.Tasks;
-using Castle.Core.Internal;
 using FluentAssertions;
 
 using Gigya.Common.Application.HttpService.Client;
 using Gigya.Common.Contracts.Exceptions;
 using Gigya.Microdot.Fakes;
-using Gigya.Microdot.Fakes.Discovery;
 using Gigya.Microdot.Interfaces.HttpService;
 using Gigya.Microdot.ServiceDiscovery;
 using Gigya.Microdot.ServiceDiscovery.HostManagement;
 using Gigya.Microdot.ServiceProxy;
 using Gigya.Microdot.SharedLogic.Events;
+using Gigya.Microdot.SharedLogic.Exceptions;
 using Gigya.Microdot.Testing;
 using Newtonsoft.Json;
 using Ninject;
@@ -376,7 +375,7 @@ namespace Gigya.Microdot.UnitTests.ServiceProxyTests
         {
             var expected = new RequestException("You request is invalid.").ThrowAndCatch();
             var messageHandler = new MockHttpMessageHandler();
-            messageHandler.When("*").Respond(HttpResponseFactory.GetResponseWithException(expected));
+            messageHandler.When("*").Respond(HttpResponseFactory.GetResponseWithException(unitTesting.Get<JsonExceptionSerializer>(), expected));
 
             Func<Task> action = async () => await CreateClient(messageHandler).ToUpper("aaaa");
 
@@ -388,7 +387,7 @@ namespace Gigya.Microdot.UnitTests.ServiceProxyTests
         {
             var expected = new RequestException("You action is invalid, Mr. Customer.", 30000).ThrowAndCatch();
             var messageHandler = new MockHttpMessageHandler();
-            messageHandler.When("*").Respond(HttpResponseFactory.GetResponseWithException(expected));
+            messageHandler.When("*").Respond(HttpResponseFactory.GetResponseWithException(ExceptionSerializer, expected));
 
             var actual = CreateClient(messageHandler).ToUpper("aaaa").ShouldThrow<RequestException>();
 
@@ -401,7 +400,7 @@ namespace Gigya.Microdot.UnitTests.ServiceProxyTests
         {
             var expected = new EnvironmentException("You environment is invalid.").ThrowAndCatch();
             var messageHandler = new MockHttpMessageHandler();
-            messageHandler.When("*").Respond(HttpResponseFactory.GetResponseWithException(expected));
+            messageHandler.When("*").Respond(HttpResponseFactory.GetResponseWithException(ExceptionSerializer, expected));
 
             var actual = CreateClient(messageHandler).ToUpper("aaaa").ShouldThrow<EnvironmentException>();
 
@@ -416,7 +415,7 @@ namespace Gigya.Microdot.UnitTests.ServiceProxyTests
         {
             var expected = new RemoteServiceException("A service is invalid.", "someUri").ThrowAndCatch();
             var messageHandler = new MockHttpMessageHandler();
-            messageHandler.When("*").Respond(HttpResponseFactory.GetResponseWithException(expected));
+            messageHandler.When("*").Respond(HttpResponseFactory.GetResponseWithException(ExceptionSerializer, expected));
 
             var actual = CreateClient(messageHandler).ToUpper("aaaa").ShouldThrow<RemoteServiceException>();
 
@@ -430,7 +429,7 @@ namespace Gigya.Microdot.UnitTests.ServiceProxyTests
         {
             var expected = new ProgrammaticException("You code is invalid.").ThrowAndCatch();
             var messageHandler = new MockHttpMessageHandler();
-            messageHandler.When("*").Respond(HttpResponseFactory.GetResponseWithException(expected));
+            messageHandler.When("*").Respond(HttpResponseFactory.GetResponseWithException(ExceptionSerializer, expected));
 
             var actual = CreateClient(messageHandler).ToUpper("aaaa").ShouldThrow<RemoteServiceException>();
 

--- a/tests/Gigya.Microdot.UnitTests/ServiceProxyTests/HttpRequestsFactory.cs
+++ b/tests/Gigya.Microdot.UnitTests/ServiceProxyTests/HttpRequestsFactory.cs
@@ -10,7 +10,7 @@ namespace Gigya.Microdot.UnitTests.ServiceProxyTests
 {
    public static class HttpResponseFactory
     {
-       public static HttpResponseMessage GetResponseWithException(Exception ex, HttpStatusCode? statusCode = null, bool withGigyaHostHeader = true) 
+       public static HttpResponseMessage GetResponseWithException(JsonExceptionSerializer exceptionSerializer, Exception ex, HttpStatusCode? statusCode = null, bool withGigyaHostHeader = true) 
        {
            var resMessage = new HttpResponseMessage { StatusCode = statusCode ?? HttpServiceListener.GetExceptionStatusCode(ex) };
            
@@ -19,7 +19,7 @@ namespace Gigya.Microdot.UnitTests.ServiceProxyTests
                resMessage.Headers.Add(GigyaHttpHeaders.ServerHostname, "host");
            }
 
-           resMessage.Content = new StringContent(JsonExceptionSerializer.Serialize(ex));
+           resMessage.Content = new StringContent(exceptionSerializer.Serialize(ex));
 
            return resMessage; 
        }

--- a/tests/Gigya.Microdot.UnitTests/ServiceProxyTests/JsonExceptionSerializerTests.cs
+++ b/tests/Gigya.Microdot.UnitTests/ServiceProxyTests/JsonExceptionSerializerTests.cs
@@ -4,12 +4,13 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Runtime.Serialization;
-
 using Gigya.Common.Application.HttpService.Client;
 using Gigya.Common.Contracts.Exceptions;
+using Gigya.Microdot.Fakes;
 using Gigya.Microdot.SharedLogic.Exceptions;
 using Gigya.Microdot.SharedLogic.Utils;
-
+using Gigya.Microdot.Testing;
+using Ninject;
 using NUnit.Framework;
 
 using Shouldly;
@@ -19,57 +20,76 @@ namespace Gigya.Microdot.UnitTests.ServiceProxyTests
     [TestFixture]
     public class JsonExceptionSerializerTests
     {
+        private JsonExceptionSerializer ExceptionSerializer { get; set; }
+
+        [SetUp]
+        public void SetUp()
+        {
+            var unitTesting = new TestingKernel<ConsoleLog>(k => 
+                k.Rebind<Func<StackTraceCleanerSettings>>().ToConstant<Func<StackTraceCleanerSettings>>(() => new StackTraceCleanerSettings
+                {
+                    RegexReplacements =
+                    {
+                        ["TidyAsyncMethodNames"] = new RegexReplace { Pattern = @"\.<(\w+)>d__\d+(?:`\d)?.MoveNext\(\)", Replacement = @".$1(async)" },
+                        ["TidyAsyncLocalFunctionNames"] = new RegexReplace { Pattern = @"\.<>c__DisplayClass(?:\d+)_(?:\d+)(?:`\d)?\.<<(\w+)>g__(\w+)\d>d.MoveNext\(\)", Replacement = @".$1.$2(async)" },
+                        ["RemoveBuildServerPath"] = new RegexReplace { Pattern = @"C:\\BuildAgent\\work\\\w+\\", Replacement = @"\" }
+                    }
+                })
+            );
+            ExceptionSerializer = unitTesting.Get<JsonExceptionSerializer>();
+        }
+
         [Test]
         public void RequestException_RoundTrip_IsIdentical()
         {
             var expected = new RequestException("message").ThrowAndCatch();
-            var json = JsonExceptionSerializer.Serialize(expected);
+            var json = ExceptionSerializer.Serialize(expected);
 
-            var actual = JsonExceptionSerializer.Deserialize(json);
+            var actual = ExceptionSerializer.Deserialize(json);
 
             actual.ShouldBeOfType<RequestException>();
             actual.Message.ShouldBe(expected.Message);
-            actual.StackTrace.ShouldBe(expected.StackTrace);
+            actual.StackTrace.ShouldNotBeNullOrEmpty();
         }
 
         [Test]
         public void CustomerFacingException_RoundTrip_IsIdentical()
         {
             var expected = new RequestException("message", 30000).ThrowAndCatch();
-            var json = JsonExceptionSerializer.Serialize(expected);
+            var json = ExceptionSerializer.Serialize(expected);
 
-            var actual = (RequestException)JsonExceptionSerializer.Deserialize(json);
+            var actual = (RequestException)ExceptionSerializer.Deserialize(json);
 
             actual.ShouldBeOfType<RequestException>();
             actual.Message.ShouldBe(expected.Message);
             actual.ErrorCode.ShouldBe(expected.ErrorCode);
-            actual.StackTrace.ShouldBe(expected.StackTrace);
+            actual.StackTrace.ShouldNotBeNullOrEmpty();
         }
 
         [Test]
         public void ExceptionTypeNotAvailable_RoundTrip_FallsBackToAvailableType()
         {
             var expected = new MyException(30000, "message") { MyNumber = 42 }.ThrowAndCatch();
-            var json = JsonExceptionSerializer.Serialize(expected);
+            var json = ExceptionSerializer.Serialize(expected);
 
             json = json.Replace("MyException", "MyNonexistentException");
-            var actual = (RequestException)JsonExceptionSerializer.Deserialize(json);
+            var actual = (RequestException)ExceptionSerializer.Deserialize(json);
 
             actual.ShouldBeOfType<RequestException>();
             actual.Message.ShouldBe(expected.Message);
             actual.ErrorCode.ShouldBe(30000);
             actual.ExtendedProperties.Count.ShouldBe(1);
             actual.ExtendedProperties.Single().ShouldBe(new KeyValuePair<string, object>("MyNumber", 42L));
-            actual.StackTrace.ShouldBe(expected.StackTrace);
+            actual.StackTrace.ShouldNotBeNullOrEmpty();
         }
 
         [Test]
         public void HttpRequestException_RoundTrip_ReturnsSubstitue()
         {
             var ex = new HttpRequestException("message").ThrowAndCatch();
-            var json = JsonExceptionSerializer.Serialize(ex);
+            var json = ExceptionSerializer.Serialize(ex);
 
-            var actual = JsonExceptionSerializer.Deserialize(json);
+            var actual = ExceptionSerializer.Deserialize(json);
 
             var envException = actual.ShouldBeOfType<EnvironmentException>();
             envException.RawMessage().ShouldEndWith(ex.RawMessage());
@@ -83,15 +103,38 @@ namespace Gigya.Microdot.UnitTests.ServiceProxyTests
             var httpEx = new HttpRequestException("HTTP request exception", webEx).ThrowAndCatch();
             var ex = new RemoteServiceException("Remote service exception", "http://foo/bar", httpEx).ThrowAndCatch();
 
-            string json = JsonExceptionSerializer.Serialize(ex);
-            var actual = JsonExceptionSerializer.Deserialize(json);
+            string json = ExceptionSerializer.Serialize(ex);
+            var actual = ExceptionSerializer.Deserialize(json);
 
             actual.ShouldBeOfType<RemoteServiceException>();
             actual.Message.ShouldBe(ex.Message);
-            actual.StackTrace.ShouldBe(ex.StackTrace);
+            actual.StackTrace.ShouldNotBeNullOrEmpty();
             actual.InnerException.ShouldBeOfType<WebException>();
             actual.InnerException.Message.ShouldBe(webEx.Message);
-            actual.InnerException.StackTrace.ShouldBe(webEx.StackTrace);
+            actual.InnerException.StackTrace.ShouldNotBeNullOrEmpty();
+        }
+
+        [Test]
+        public void InnerException_RoundTrip_AllStackTracesCleaned()
+        {
+            var webEx = new WebException("Web exception").ThrowAndCatchAsync();
+            var ex = new RemoteServiceException("Remote service exception", "http://foo/bar", webEx).ThrowAndCatchAsync();
+
+            string json = ExceptionSerializer.Serialize(ex);
+            var actual = ExceptionSerializer.Deserialize(json);
+
+            actual.ShouldBeOfType<RemoteServiceException>();
+            actual.Message.ShouldBe(ex.Message);
+            actual.StackTrace.ShouldNotBeNullOrEmpty();
+            actual.StackTrace.ShouldNotContain("at System.Runtime");
+            actual.StackTrace.ShouldNotContain("End of stack trace from previous location");
+            actual.StackTrace.ShouldNotContain("__");
+            actual.InnerException.ShouldBeOfType<WebException>();
+            actual.InnerException.Message.ShouldBe(webEx.Message);
+            actual.InnerException.StackTrace.ShouldNotBeNullOrEmpty();
+            actual.InnerException.StackTrace.ShouldNotContain("at System.Runtime");
+            actual.InnerException.StackTrace.ShouldNotContain("End of stack trace");
+            actual.InnerException.StackTrace.ShouldNotContain("__");
         }
     }
 

--- a/tests/Gigya.Microdot.UnitTests/ServiceProxyTests/MetricsTests.cs
+++ b/tests/Gigya.Microdot.UnitTests/ServiceProxyTests/MetricsTests.cs
@@ -151,7 +151,7 @@ namespace Gigya.Microdot.UnitTests.ServiceProxyTests
         [Test]
         public async Task NullExceptionReceivedTest()
         {
-            var resMessage = HttpResponseFactory.GetResponseWithException(new NullReferenceException());
+            var resMessage = HttpResponseFactory.GetResponseWithException(ExceptionSerializer, new NullReferenceException());
             
             var messageHandler = new MockHttpMessageHandler();
             messageHandler.When("*").Respond(resMessage);
@@ -174,7 +174,7 @@ namespace Gigya.Microdot.UnitTests.ServiceProxyTests
         [Test]
         public async Task RequestExceptionReceivedTest()
         {
-            var resMessage = HttpResponseFactory.GetResponseWithException(new RequestException("Post not allowed"), HttpStatusCode.MethodNotAllowed);
+            var resMessage = HttpResponseFactory.GetResponseWithException(ExceptionSerializer, new RequestException("Post not allowed"), HttpStatusCode.MethodNotAllowed);
             
             var messageHandler = new MockHttpMessageHandler();
             messageHandler.When("*").Respond(resMessage);


### PR DESCRIPTION
Made JsonExceptionSerializer non-static. Added StackTraceEnhancer which cleans stack traces and adds breadcrumbs (where the exception flowed through), and plugged it into JsonExceptionSerializer and LogEventPublisher. Added "ex.stackTraceUnclean" field to Event. Added test for stack trace cleaning.