### PR TITLE
Fixed backwards compatibility with SerializableException.Breadcrumbs …

### DIFF
--- a/Gigya.Microdot.Hosting/HttpService/HttpServiceListener.cs
+++ b/Gigya.Microdot.Hosting/HttpService/HttpServiceListener.cs
@@ -279,8 +279,6 @@ namespace Gigya.Microdot.Hosting.HttpService
                 return e;
 
             var ex = GetAllExceptions(e).FirstOrDefault(x => (x is TargetInvocationException || x is AggregateException) == false);
-            if (ex is SerializableException == false)
-                ex = new UnhandledException(ex);
 
             return ex;
         }

--- a/Gigya.Microdot.Interfaces/Logging/IStackTraceEnhancer.cs
+++ b/Gigya.Microdot.Interfaces/Logging/IStackTraceEnhancer.cs
@@ -1,10 +1,11 @@
-﻿using Gigya.Common.Contracts.Exceptions;
+﻿using System;
+using Newtonsoft.Json.Linq;
 
 namespace Gigya.Microdot.Interfaces.Logging
 {
     public interface IStackTraceEnhancer
     {
         string Clean(string stackTrace);
-        string AddBreadcrumb(SerializableException exception);
+        JObject ToJObjectWithBreadcrumb(Exception exception);
     }
 }

--- a/Gigya.Microdot.SharedLogic/Exceptions/StackTraceEnhancer.cs
+++ b/Gigya.Microdot.SharedLogic/Exceptions/StackTraceEnhancer.cs
@@ -38,7 +38,7 @@ namespace Gigya.Microdot.SharedLogic.Exceptions
                 return jobject;
 
             var breadcrumbTarget = jobject.Property("RemoteStackTraceString");
-            breadcrumbTarget = breadcrumbTarget.Value.Type == JTokenType.String ? breadcrumbTarget : jobject.Property("StackTraceString");
+            breadcrumbTarget = breadcrumbTarget?.Value.Type == JTokenType.String ? breadcrumbTarget : jobject.Property("StackTraceString");
 
             if (breadcrumbTarget == null)
             {

--- a/Gigya.ServiceContract/Exceptions/ProgrammaticException.cs
+++ b/Gigya.ServiceContract/Exceptions/ProgrammaticException.cs
@@ -69,7 +69,7 @@ namespace Gigya.Common.Contracts.Exceptions
     /// as an RemoteServiceException, having an inner exception copied over. You should never throw this exception from
     /// your code.
     /// </summary>
-    [Serializable]
+    [Serializable, Obsolete("No longer used, preserved for backwards compatibility with older servers.")]
     public class UnhandledException : ProgrammaticException
     {
         /// <summary>

--- a/Gigya.ServiceContract/Exceptions/SerializableException.cs
+++ b/Gigya.ServiceContract/Exceptions/SerializableException.cs
@@ -215,9 +215,12 @@ namespace Gigya.Common.Contracts.Exceptions
 
 		    try
 		    {
-                _breadcrumbs = (Breadcrumb[])info.GetValue(BREADCRUMBS_KEY, typeof(Breadcrumb[]));
+		        _breadcrumbs = (Breadcrumb[])info.GetValue(BREADCRUMBS_KEY, typeof(Breadcrumb[]));
+		    }
+		    catch (SerializationException)
+		    {
+		        _breadcrumbs = new Breadcrumb[0];
             }
-            catch (SerializationException) { }
         }
 
 

--- a/Gigya.ServiceContract/Exceptions/SerializableException.cs
+++ b/Gigya.ServiceContract/Exceptions/SerializableException.cs
@@ -213,7 +213,11 @@ namespace Gigya.Common.Contracts.Exceptions
                 }
             }
 
-		    _breadcrumbs = (Breadcrumb[])info.GetValue(BREADCRUMBS_KEY, typeof(Breadcrumb[]));
+		    try
+		    {
+                _breadcrumbs = (Breadcrumb[])info.GetValue(BREADCRUMBS_KEY, typeof(Breadcrumb[]));
+            }
+            catch (SerializationException) { }
         }
 
 

--- a/Gigya.ServiceContract/Properties/AssemblyInfo.cs
+++ b/Gigya.ServiceContract/Properties/AssemblyInfo.cs
@@ -40,9 +40,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 
 
-[assembly: AssemblyInformationalVersion("2.4.17")]// if pre-release should be in the format of "2.4.11-pre01".
-[assembly: AssemblyVersion("2.4.17")]
-[assembly: AssemblyFileVersion("2.4.17")]
+[assembly: AssemblyInformationalVersion("2.4.18")]// if pre-release should be in the format of "2.4.11-pre01".
+[assembly: AssemblyVersion("2.4.18")]
+[assembly: AssemblyFileVersion("2.4.18")]
 
 [assembly: AssemblyDescription("")]
 

--- a/tests/Gigya.Microdot.UnitTests/ServiceListenerTests/HttpServiceListenerTests.cs
+++ b/tests/Gigya.Microdot.UnitTests/ServiceListenerTests/HttpServiceListenerTests.cs
@@ -80,14 +80,14 @@ namespace Gigya.Microdot.UnitTests.ServiceListenerTests
 
 
         [Test]
-        public async Task  RequestWithException_ShouldWrapWithUnhandledException()
+        public async Task  RequestWithException_ShouldNotWrapWithUnhandledException()
         {
             _testinghost.Instance.When(a => a.DoSomething()).Throw(x => new ArgumentException("MyEx"));
             var request = await GetRequestFor<IDemoService>(p => p.DoSomething());
 
             var responseJson = await (await new HttpClient().SendAsync(request)).Content.ReadAsStringAsync();
             var responseException = _exceptionSerializer.Deserialize(responseJson);
-            responseException.ShouldBeOfType<UnhandledException>();
+            responseException.ShouldBeOfType<ArgumentException>();
         }
 
 

--- a/tests/Gigya.Microdot.UnitTests/ServiceProxyTests/JsonExceptionSerializerTests.cs
+++ b/tests/Gigya.Microdot.UnitTests/ServiceProxyTests/JsonExceptionSerializerTests.cs
@@ -26,7 +26,7 @@ namespace Gigya.Microdot.UnitTests.ServiceProxyTests
         public void SetUp()
         {
             var unitTesting = new TestingKernel<ConsoleLog>(k => 
-                k.Rebind<Func<StackTraceCleanerSettings>>().ToConstant<Func<StackTraceCleanerSettings>>(() => new StackTraceCleanerSettings
+                k.Rebind<Func<StackTraceEnhancerSettings>>().ToConstant<Func<StackTraceEnhancerSettings>>(() => new StackTraceEnhancerSettings
                 {
                     RegexReplacements =
                     {


### PR DESCRIPTION
…and improved handling of where they're added.Non-SerializableExceptions thrown by a service are no longer wrapped in UnhandledException (which is now obsolete).