### PR TITLE
Feature/#59643 rename refactor missin host exception (#116)

### DIFF
--- a/Gigya.Microdot.ServiceDiscovery/ConfigDiscoverySource.cs
+++ b/Gigya.Microdot.ServiceDiscovery/ConfigDiscoverySource.cs
@@ -111,7 +111,7 @@ namespace Gigya.Microdot.ServiceDiscovery
             }
             else
             {
-                return new MissingHostException("All defined hosts for the requested service are unreachable. " +
+                return new ServiceUnreachableException("All endpoints defined by the configuration for the requested service are unreachable. " +
                                                 "Please make sure the remote hosts specified in the configuration are correct and are " +
                                                 "functioning properly. See tags for the name of the requested service, the list of hosts " +
                                                 "that are unreachable, and the configuration path they were loaded from. See the inner " +

--- a/Gigya.Microdot.ServiceDiscovery/ConsulDiscoverySource.cs
+++ b/Gigya.Microdot.ServiceDiscovery/ConsulDiscoverySource.cs
@@ -143,13 +143,13 @@ namespace Gigya.Microdot.ServiceDiscovery
                 else if (endPointsResult.Error != null)
                     return new EnvironmentException("Error calling Consul. See tags for details.", unencrypted: tags);
                 else if (endPointsResult.IsQueryDefined == false)
-                    return new EnvironmentException("Service doesn't exist on Consul. See tags for details.", unencrypted: tags);
+                    return new ServiceUnreachableException("Service doesn't exist on Consul. See tags for details.", unencrypted: tags);
                 else
                     return new EnvironmentException("No endpoint were specified in Consul for the requested service and service's active version.", unencrypted: tags);
             }
             else
             {
-                return new MissingHostException("All endpoints defined by Consul for the requested service are unreachable. " +
+                return new ServiceUnreachableException("All endpoints defined by Consul for the requested service are unreachable. " +
                                                 "Please make sure the endpoints on Consul are correct and are functioning properly. " +
                                                 "See tags for the name of the requested service, and address of consul from which they were loaded. " +
                                                 "exception for one of the causes a remote host was declared unreachable.",

--- a/Gigya.Microdot.ServiceDiscovery/HostManagement/MissingHostException.cs
+++ b/Gigya.Microdot.ServiceDiscovery/HostManagement/MissingHostException.cs
@@ -27,13 +27,13 @@ using Gigya.Common.Contracts.Exceptions;
 namespace Gigya.Microdot.ServiceDiscovery.HostManagement
 {
     [Serializable]
-    public class MissingHostException:EnvironmentException
+    public class ServiceUnreachableException:EnvironmentException
     {
-        public MissingHostException(string message, Exception innerException = null, Tags encrypted = null, Tags unencrypted = null)
+        public ServiceUnreachableException(string message, Exception innerException = null, Tags encrypted = null, Tags unencrypted = null)
             : base(message, innerException, encrypted, unencrypted) { }
 
 
-        public MissingHostException(SerializationInfo info, StreamingContext context)
+        public ServiceUnreachableException(SerializationInfo info, StreamingContext context)
             : base(info, context) { }
     }
 }

--- a/Gigya.Microdot.ServiceDiscovery/HostManagement/OverriddenRemoteHost.cs
+++ b/Gigya.Microdot.ServiceDiscovery/HostManagement/OverriddenRemoteHost.cs
@@ -44,7 +44,7 @@ namespace Gigya.Microdot.ServiceDiscovery.HostManagement
 
         public bool ReportFailure(Exception ex = null)
         {
-            throw new MissingHostException("Failed to reach an overridden remote host. Please make sure the " +
+            throw new ServiceUnreachableException("Failed to reach an overridden remote host. Please make sure the " +
                                            "overrides specified are reachable from all services that participate in the request. See inner " +
                                            "exception for details and tags for information on which override caused this issue.",
                 ex,

--- a/Gigya.Microdot.ServiceDiscovery/LocalDiscoverySource.cs
+++ b/Gigya.Microdot.ServiceDiscovery/LocalDiscoverySource.cs
@@ -41,7 +41,7 @@ namespace Gigya.Microdot.ServiceDiscovery
 
         public override Exception AllEndpointsUnreachable(EndPointsResult endPointsResult, Exception lastException, string lastExceptionEndPoint, string unreachableHosts)
         {
-            return new MissingHostException("Service source is configured to 'Local' Discovery mode, but is not reachable on local machine. See tags for more details.",
+            return new ServiceUnreachableException("Service source is configured to 'Local' Discovery mode, but is not reachable on local machine. See tags for more details.",
                 lastException,
                 unencrypted: new Tags
                 {

--- a/SolutionVersion.cs
+++ b/SolutionVersion.cs
@@ -28,9 +28,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("© 2017 Gigya Inc.")]
 [assembly: AssemblyDescription("Microdot Framework")]
 
-[assembly: AssemblyVersion("1.7.5.0")]
-[assembly: AssemblyFileVersion("1.7.5.0")] 
-[assembly: AssemblyInformationalVersion("1.7.5.0")]
+[assembly: AssemblyVersion("1.7.6.0")]
+[assembly: AssemblyFileVersion("1.7.6.0")] 
+[assembly: AssemblyInformationalVersion("1.7.6.0")]
 
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/tests/Gigya.Microdot.UnitTests/ServiceProxyTests/BehaviorTests.cs
+++ b/tests/Gigya.Microdot.UnitTests/ServiceProxyTests/BehaviorTests.cs
@@ -195,7 +195,7 @@ namespace Gigya.Microdot.UnitTests.ServiceProxyTests
                 var request = new HttpServiceRequest("testMethod", new Dictionary<string, object>());
 
                 Func<Task> act = () => serviceProxy.Invoke(request, typeof(string));
-                await act.ShouldThrowAsync<MissingHostException>();
+                await act.ShouldThrowAsync<ServiceUnreachableException>();
                 counter.ShouldBe(4);
             }
         }
@@ -299,7 +299,7 @@ namespace Gigya.Microdot.UnitTests.ServiceProxyTests
                 {
                     Func<Task> act = () => serviceProxy.Invoke(request, typeof(string));
 
-                    await act.ShouldThrowAsync<MissingHostException>();
+                    await act.ShouldThrowAsync<ServiceUnreachableException>();
                 }
                 counter.ShouldBe(3);
             }
@@ -350,7 +350,7 @@ namespace Gigya.Microdot.UnitTests.ServiceProxyTests
                 {
                     Func<Task> act = () => serviceProxy.Invoke(request, typeof(string));
 
-                    await act.ShouldThrowAsync<MissingHostException>();
+                    await act.ShouldThrowAsync<ServiceUnreachableException>();
                 }
                 counter.ShouldBe(2);
             }


### PR DESCRIPTION
* 1. rename MissingHostException to ServiceUnreachableException

2. When a service does not exist in Consul return ServiceUnreachableException instead of EnvironmentException

(feature #59643)

Commit by Nir Huppert <nirh@gigya-inc.com>
On branch: refs/heads/feature/#59643_rename_refactor_MissinHostException

* Update version to 1.7.6

Commit by Nir Huppert <nirh@gigya-inc.com>
On branch: refs/heads/feature/#59643_rename_refactor_MissinHostException