### PR TITLE
Feature/#61635 log individual request object fields and support (#155)

### DIFF
--- a/Gigya.Microdot.Hosting/Events/ServiceCallEvent.cs
+++ b/Gigya.Microdot.Hosting/Events/ServiceCallEvent.cs
@@ -32,12 +32,12 @@ namespace Gigya.Microdot.Hosting.Events
 {
     public class ServiceCallEvent : StatsEvent
     {
-   
+
         protected Regex ExcludeStackTraceForErrorCodeRegex => Configuration.ExcludeStackTraceRule;
 
         internal double? ActualTotalTime { get; set; }
 
-      
+
         public override double? TotalTime => ActualTotalTime;
 
         public override string EventType => EventConsts.ServerReqType;
@@ -62,33 +62,32 @@ namespace Gigya.Microdot.Hosting.Events
 
         /// <summary>  Sensitive Service method arguments </summary>
         [EventField("params", Encrypt = true)]
-        public IEnumerable<KeyValuePair<string, string>> EncryptedServiceMethodArguments => LazyEncryptedRequestParams.GetValue(this);
+        public IEnumerable<KeyValuePair<string, object>> EncryptedServiceMethodArguments => LazyEncryptedRequestParams.GetValue(this);
 
         /// <summary> NonSensitive Service method arguments </summary>
 
-        [EventField("params", Encrypt = false)]
-        public IEnumerable<KeyValuePair<string, string>> UnencryptedServiceMethodArguments => LazyUnencryptedRequestParams.GetValue(this);
+        [EventField("params", Encrypt = false, TruncateIfLong = true)]
+        public IEnumerable<KeyValuePair<string, object>> UnencryptedServiceMethodArguments => LazyUnencryptedRequestParams.GetValue(this);
 
 
-        private readonly SharedLogic.Utils.Lazy<List<KeyValuePair<string, string>>, ServiceCallEvent> LazyEncryptedRequestParams = new SharedLogic.Utils.Lazy<List<KeyValuePair<string, string>>, ServiceCallEvent>(this_ => this_.GetRequestParams(Sensitivity.Sensitive).ToList());
-        private readonly SharedLogic.Utils.Lazy<List<KeyValuePair<string, string>>, ServiceCallEvent> LazyUnencryptedRequestParams = new SharedLogic.Utils.Lazy<List<KeyValuePair<string, string>>, ServiceCallEvent>(this_ => this_.GetRequestParams(Sensitivity.NonSensitive).ToList());
+        private readonly SharedLogic.Utils.Lazy<List<KeyValuePair<string, object>>, ServiceCallEvent> LazyEncryptedRequestParams = new SharedLogic.Utils.Lazy<List<KeyValuePair<string, object>>, ServiceCallEvent>(this_ => this_.GetRequestParams(Sensitivity.Sensitive).ToList());
+        private readonly SharedLogic.Utils.Lazy<List<KeyValuePair<string, object>>, ServiceCallEvent> LazyUnencryptedRequestParams = new SharedLogic.Utils.Lazy<List<KeyValuePair<string, object>>, ServiceCallEvent>(this_ => this_.GetRequestParams(Sensitivity.NonSensitive).ToList());
 
 
         public IEnumerable<Param> Params { get; set; }
 
-
-        private IEnumerable<KeyValuePair<string, string>> GetRequestParams(Sensitivity sensitivity)
+        private IEnumerable<KeyValuePair<string, object>> GetRequestParams(Sensitivity sensitivity)
         {
-            
-            if (!Configuration.ExcludeParams && Params != null)
-            {
-                foreach (var param in Params.Where(param => param.Value != null && param.Sensitivity == sensitivity))
-                {
-                    var val = param.Value.Substring(0, Math.Min(param.Value.Length, Configuration.ParamTruncateLength));
 
-                    yield return new KeyValuePair<string, string>(param.Name, val);
-                }
+            if (Params != null)
+            {
+                return Params.Where(param => !Configuration.ExcludeParams && Params != null)
+                               .Where(param => param.Value != null && param.Sensitivity == sensitivity)
+                               .Select(_ => new KeyValuePair<string, object>(_.Name, _.Value));
             }
+
+            return Enumerable.Empty<KeyValuePair<string, object>>();
+
         }
     }
 }

--- a/Gigya.Microdot.Hosting/HttpService/ServerRequestPublisher.cs
+++ b/Gigya.Microdot.Hosting/HttpService/ServerRequestPublisher.cs
@@ -42,21 +42,12 @@ namespace Gigya.Microdot.Hosting.HttpService
 
             var metaData = _serviceEndPointDefinition.GetMetaData(serviceMethod);
             var arguments = (requestData.Arguments ?? new OrderedDictionary()).Cast<DictionaryEntry>();
-            var @params = new List<Param>();
 
-            foreach (var argument in arguments)
-            {
-                foreach (var (name, value, sensitivity) in ExtractParamValues(argument, metaData))
-                {
-                    @params.Add(new Param{
-                        Name = name,
-                        Value = value is string ? value.ToString() : JsonConvert.SerializeObject(value),
-                        Sensitivity = sensitivity
-                    });
-                }
-            }
-
-            callEvent.Params = @params;
+            callEvent.Params = arguments.SelectMany(_ => ExtractParamValues(_, metaData)).Select(_ => new Param{
+                Name = _.name,
+                Value = _.value,
+                Sensitivity = _.sensitivity,
+            });
             callEvent.Exception = ex;
             callEvent.ActualTotalTime = requestTime;
             callEvent.ErrCode = ex != null ? null : (int?)0;
@@ -79,7 +70,7 @@ namespace Gigya.Microdot.Hosting.HttpService
                     foreach (var metaParam in metaParams)
                     {
                         var tuple = (
-                            name: $"{key}.{metaParam.Name}",
+                            name: $"{key}_{metaParam.Name}",
                             value: metaParam.Value,
                             sensitivity: metaParam.Sensitivity ?? sensitivity);
 

--- a/Gigya.Microdot.Interfaces/Events/EventFieldAttribute.cs
+++ b/Gigya.Microdot.Interfaces/Events/EventFieldAttribute.cs
@@ -43,6 +43,8 @@ namespace Gigya.Microdot.Interfaces.Events
         /// Cannot be used along with <see cref="Encrypt"/>, since encrypted tags are by definition always strings.</summary>
         public bool AppendTypeSuffix;
 
+        public bool TruncateIfLong = false;
+
         public EventFieldAttribute(string _name, object default_value = null)
         {
             Name = _name;

--- a/Gigya.Microdot.SharedLogic/Events/Param.cs
+++ b/Gigya.Microdot.SharedLogic/Events/Param.cs
@@ -30,7 +30,7 @@ namespace Gigya.Microdot.SharedLogic.Events
     public class Param
     {
         public string Name;
-        public string Value;
+        public object Value;
         public Sensitivity Sensitivity;
     }
 

--- a/Gigya.Microdot.Testing.Shared/Gigya.Microdot.Testing.Shared.csproj
+++ b/Gigya.Microdot.Testing.Shared/Gigya.Microdot.Testing.Shared.csproj
@@ -48,6 +48,7 @@
     <Compile Include="..\SolutionVersion.cs">
       <Link>Properties\SolutionVersion.cs</Link>
     </Compile>
+    <Compile Include="Helpers\DissectPropertyInfoMetadata.cs" />
     <Compile Include="Service\ServiceTesterExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Service\NonOrleansServiceTester.cs" />
@@ -218,6 +219,17 @@
       <ItemGroup>
         <Reference Include="System.Threading.Tasks.Extensions">
           <HintPath>..\packages\System.Threading.Tasks.Extensions\lib\netstandard1.0\System.Threading.Tasks.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5.1'">
+      <ItemGroup>
+        <Reference Include="System.ValueTuple">
+          <HintPath>..\packages\System.ValueTuple\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/Gigya.Microdot.Testing.Shared/Helpers/DissectPropertyInfoMetadata.cs
+++ b/Gigya.Microdot.Testing.Shared/Helpers/DissectPropertyInfoMetadata.cs
@@ -4,11 +4,11 @@ using System.Reflection;
 using Gigya.Microdot.SharedLogic.Events;
 using Gigya.ServiceContract.Attributes;
 
-namespace Gigya.Microdot.Orleans.Hosting.UnitTests
+namespace Gigya.Microdot.Testing.Shared.Helpers
 {
-    internal static class DissectPropertyInfoMetadata
+    public static class DissectPropertyInfoMetadata
     {
-        internal static IEnumerable<(PropertyInfo PropertyInfo, Sensitivity Sensitivity)> DissectPropertis<TType>(TType instance, Sensitivity defualtSensitivity = Sensitivity.Sensitive) where TType : class
+        public static IEnumerable<(PropertyInfo PropertyInfo, Sensitivity Sensitivity)> DissectPropertis<TType>(TType instance, Sensitivity defualtSensitivity = Sensitivity.Sensitive) where TType : class
         {
             foreach (var propertyInfo in instance.GetType().GetProperties())
             {
@@ -17,7 +17,7 @@ namespace Gigya.Microdot.Orleans.Hosting.UnitTests
             }
         }
 
-        internal static Sensitivity? ExtractSensitivityFromPropertyInfo(PropertyInfo propertyInfo)
+        public static Sensitivity? ExtractSensitivityFromPropertyInfo(PropertyInfo propertyInfo)
         {
             var attribute = propertyInfo.GetCustomAttributes()
                 .FirstOrDefault(x => x is SensitiveAttribute || x is NonSensitiveAttribute);
@@ -34,6 +34,7 @@ namespace Gigya.Microdot.Orleans.Hosting.UnitTests
                     return Sensitivity.Sensitive;
                 }
 
+                // If we got here, we definitely found a NonSensitiveAttribute
                 return Sensitivity.NonSensitive;
             }
 

--- a/Gigya.Microdot.Testing.Shared/paket.references
+++ b/Gigya.Microdot.Testing.Shared/paket.references
@@ -3,3 +3,4 @@ Ninject
 Microsoft.Orleans.Core
 NSubstitute
 System.Threading.Tasks.Dataflow
+System.ValueTuple

--- a/SolutionVersion.cs
+++ b/SolutionVersion.cs
@@ -28,9 +28,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("© 2018 Gigya Inc.")]
 [assembly: AssemblyDescription("Microdot Framework")]
 
-[assembly: AssemblyVersion("1.9.3.0")]
-[assembly: AssemblyFileVersion("1.9.3.0")] 
-[assembly: AssemblyInformationalVersion("1.9.3.0")]
+[assembly: AssemblyVersion("1.9.4.0")]
+[assembly: AssemblyFileVersion("1.9.4.0")] 
+[assembly: AssemblyInformationalVersion("1.9.4.0")]
 
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/paket.lock
+++ b/paket.lock
@@ -8,7 +8,7 @@ NUGET
     DataAnnotationsValidator (2.1)
     FluentAssertions (5.2)
       System.ValueTuple (>= 4.4)
-    Gigya.ServiceContract (2.5.2)
+    Gigya.ServiceContract (2.5.4)
       Newtonsoft.Json (>= 9.0.1)
     Metrics.NET (0.5.5)
     Microsoft.Bcl (1.1.10)

--- a/tests/Gigya.Microdot.Orleans.Hosting.UnitTests/Gigya.Microdot.Orleans.Hosting.UnitTests.csproj
+++ b/tests/Gigya.Microdot.Orleans.Hosting.UnitTests/Gigya.Microdot.Orleans.Hosting.UnitTests.csproj
@@ -44,7 +44,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInitialize.cs" />
-    <Compile Include="DissectPropertyInfoMetadata.cs" />
     <Compile Include="LogFieldAttributeValidatorTest.cs" />
     <Compile Include="Microservice\CalculatorService\CalculatorServiceGrain.cs" />
     <Compile Include="Microservice\CalculatorService\CalculatorServiceHost.cs" />

--- a/tests/Gigya.Microdot.Orleans.Hosting.UnitTests/Microservice/CalculatorService/CalculatorServiceGrain.cs
+++ b/tests/Gigya.Microdot.Orleans.Hosting.UnitTests/Microservice/CalculatorService/CalculatorServiceGrain.cs
@@ -30,6 +30,7 @@ using Gigya.Microdot.Interfaces.Events;
 using Gigya.Microdot.Interfaces.Logging;
 using Gigya.Microdot.Orleans.Hosting.Events;
 using Gigya.Microdot.SharedLogic.Events;
+using Gigya.Microdot.Testing.Shared.Helpers;
 using Gigya.ServiceContract.Attributes;
 using Gigya.ServiceContract.HttpService;
 using Newtonsoft.Json;
@@ -153,21 +154,21 @@ namespace Gigya.Microdot.Orleans.Hosting.UnitTests.Microservice.CalculatorServic
 
                 foreach (var s in sensitive)
                 {
-                    serviceCallEvent.EncryptedServiceMethodArguments.ShouldContain(x1 => x1.Value == s);
-                    serviceCallEvent.UnencryptedServiceMethodArguments.ShouldNotContain(x1 => x1.Value == s);
+                    serviceCallEvent.EncryptedServiceMethodArguments.ShouldContain(x1 => x1.Value.ToString() == s);
+                    serviceCallEvent.UnencryptedServiceMethodArguments.ShouldNotContain(x1 => x1.Value.ToString() == s);
                 }
 
                 foreach (var s in NoneSensitive)
                 {
-                    serviceCallEvent.UnencryptedServiceMethodArguments.ShouldContain(x1 => x1.Value == s);
-                    serviceCallEvent.EncryptedServiceMethodArguments.ShouldNotContain(x1 => x1.Value == s);
+                    serviceCallEvent.UnencryptedServiceMethodArguments.ShouldContain(x1 => x1.Value.ToString() == s);
+                    serviceCallEvent.EncryptedServiceMethodArguments.ShouldNotContain(x1 => x1.Value.ToString() == s);
 
                 }
 
                 foreach (var n in NotExists)
                 {
-                    serviceCallEvent.UnencryptedServiceMethodArguments.ShouldNotContain(x1 => x1.Value == n);
-                    serviceCallEvent.EncryptedServiceMethodArguments.ShouldNotContain(x1 => x1.Value == n);
+                    serviceCallEvent.UnencryptedServiceMethodArguments.ShouldNotContain(x1 => x1.Value.ToString() == n);
+                    serviceCallEvent.EncryptedServiceMethodArguments.ShouldNotContain(x1 => x1.Value.ToString() == n);
                 }
 
             }
@@ -212,11 +213,11 @@ namespace Gigya.Microdot.Orleans.Hosting.UnitTests.Microservice.CalculatorServic
 
                 if (metadata.PropertyInfo.PropertyType.IsClass == true && metadata.PropertyInfo.PropertyType != typeof(string))
                 {
-                    JsonConvert.SerializeObject(metadata.PropertyInfo.GetValue(person, null)).ShouldBe(argument.Value); //Json validation
+                    JsonConvert.SerializeObject(metadata.PropertyInfo.GetValue(person, null)).ShouldBe(JsonConvert.SerializeObject(argument.Value)); //Json validation
                 }
                 else
                 {
-                    metadata.PropertyInfo.GetValue(person, null).ToString().ShouldBe(argument.Value);
+                    metadata.PropertyInfo.GetValue(person, null).ShouldBe(argument.Value);
                 }
 
                 expectedSecritiveProperties.FirstOrDefault(x => x.NewPropertyName.Equals(argument.Key)).ShouldBeNull();
@@ -235,7 +236,7 @@ namespace Gigya.Microdot.Orleans.Hosting.UnitTests.Microservice.CalculatorServic
 
         private string AddPrifix(string prefix, string param)
         {
-            return $"{prefix.Substring(0, 1).ToLower()}{prefix.Substring(1)}.{param}";
+            return $"{prefix.Substring(0, 1).ToLower()}{prefix.Substring(1)}_{param}";
         }
 
         public async Task LogGrainId()

--- a/tests/Gigya.Microdot.UnitTests/Events/EventSerializationTests.cs
+++ b/tests/Gigya.Microdot.UnitTests/Events/EventSerializationTests.cs
@@ -19,9 +19,9 @@ namespace Gigya.Microdot.UnitTests.Events
     public class EventSerializationTests
     {
         EventSerializer SerializerWithStackTrace { get; } = new EventSerializer(() => new EventConfiguration(), new NullEnvironmentsVariableProvider(),
-            new StackTraceEnhancer(() => new StackTraceEnhancerSettings(), new NullEnvironmentsVariableProvider()));
+            new StackTraceEnhancer(() => new StackTraceEnhancerSettings(), new NullEnvironmentsVariableProvider()), () => new EventConfiguration());
         EventSerializer SerializerWithoutStackTrace { get; } = new EventSerializer(() => new EventConfiguration { ExcludeStackTraceRule = new Regex(".*") }, new NullEnvironmentsVariableProvider(),
-            new StackTraceEnhancer(() => new StackTraceEnhancerSettings(), new NullEnvironmentsVariableProvider()));
+            new StackTraceEnhancer(() => new StackTraceEnhancerSettings(), new NullEnvironmentsVariableProvider()), () => new EventConfiguration());
 
         [OneTimeSetUp]
         public void OneTimeSetUp()


### PR DESCRIPTION
* #61635 Skeleton - adding CacheMetadata,ReflectionMetaDataExtension and adding ReflectionMetaDataExtensionTest

* #61635 adding working unit-test

* #61635 CacheMetadata

* cache data amedments

* merge with master-update

* HttpListener adding ability to write coplex pocos

* ReflectionMetadataExtension refactoring

* LamdaExtraction intreducing

* humble code cleans

* CacheMetadata amedments - unittest doesn't work

* HttpListener amedments

* Metadata amedments on Sensitivity

* Adding Tuple value
Adding DissectPropertyInfo
Modification SendComplexRequest

* added amedments but there are unit test not working and some ignored

* HttpServiceListener refactoring

* HttpServiceListener refactoring

* HttpServiceListener refactoring

* amedments after code review with Daniel

* Adding ParametersLogFieldAttribute

* moving cache metadata

* CacheMetadata->MetadataPropertiesCache

* pre-code review with Eran

* pre-code review with Eran part 2

* pre-code review with Eran part 2

* pre-code review with Eran part 3

* code review with david

* code review with eran part 4

* unit tests

* adding ServerRequestPublisher

* Eran remarks regarding errors exceptions

* Properties Cache erro handle

* validator skeleton

* validator skeleton

* validator skeleton

* Validator - UnitTests

* merge with develop

* Csproj fix with Alon

* Remove LogField Duplication

* Typos and Comments

* Code review with David

*  .==>_

* final refactoring

* version 1.9.4.0

* review

* review

* test fix --- After Daniel review