### PR TITLE
#116416 changing the conditions for loading client certificate

### DIFF
--- a/Gigya.Microdot.Hosting/HttpService/HttpServiceListener.cs
+++ b/Gigya.Microdot.Hosting/HttpService/HttpServiceListener.cs
@@ -139,7 +139,7 @@ namespace Gigya.Microdot.Hosting.HttpService
             LoadSheddingConfig = loadSheddingConfig;
             AppInfo = appInfo;
 
-            if (ServiceEndPointDefinition.HttpsPort != null && ServiceEndPointDefinition.ClientCertificateVerification != ServerClientCertificateVerificationMode.Disable)
+            if (ServiceEndPointDefinition.HttpsPort != null && ServiceEndPointDefinition.ClientCertificateVerification != ClientCertificateVerificationMode.Disable)
                 ServerRootCertHash = certificateLocator.GetCertificate("Service").GetHashOfRootCertificate();
 
             Listener = new HttpListener {IgnoreWriteExceptions = true};
@@ -521,7 +521,7 @@ namespace Gigya.Microdot.Hosting.HttpService
                     unencrypted: new Tags { { "requestIsSecure", context.Request.IsSecureConnection.ToString() }, { "requestedUrl", context.Request.Url.ToString() } });
             }
 
-            if (ServiceEndPointDefinition.ClientCertificateVerification == ServerClientCertificateVerificationMode.Disable)
+            if (ServiceEndPointDefinition.ClientCertificateVerification == ClientCertificateVerificationMode.Disable)
             {
                 return; 
             }

--- a/Gigya.Microdot.Hosting/HttpService/IServiceEndPointDefinition.cs
+++ b/Gigya.Microdot.Hosting/HttpService/IServiceEndPointDefinition.cs
@@ -40,7 +40,7 @@ namespace Gigya.Microdot.Hosting.HttpService
         /// <summary>
         /// Controls the client certificate verification logic
         /// </summary>
-        ServerClientCertificateVerificationMode ClientCertificateVerification { get; }
+        ClientCertificateVerificationMode ClientCertificateVerification { get; }
 
         int SiloGatewayPort { get; }
 

--- a/Gigya.Microdot.Hosting/HttpService/ServiceEndPointDefinition.cs
+++ b/Gigya.Microdot.Hosting/HttpService/ServiceEndPointDefinition.cs
@@ -107,8 +107,8 @@ namespace Gigya.Microdot.Hosting.HttpService
             // Use service configuration if exists, if not use global configuration
             UseSecureChannel = serviceConfig.ServiceHttpsOverride ?? config.ServiceHttpsOverride;
 
-            ClientCertificateVerification = serviceConfig.PerformServerClientCertificateVerification ??
-                                            config.PerformServerClientCertificateVerification;
+            ClientCertificateVerification = serviceConfig.ClientCertificateVerification ??
+                                            config.ClientCertificateVerification;
 
             if (config.PortAllocation.IsSlotMode == false && serviceArguments.SlotNumber == null)
             {
@@ -177,7 +177,7 @@ namespace Gigya.Microdot.Hosting.HttpService
             }
         }
 
-        public ServerClientCertificateVerificationMode ClientCertificateVerification { get;}
+        public ClientCertificateVerificationMode ClientCertificateVerification { get;}
 
 
         public ServiceMethod Resolve(InvocationTarget target)

--- a/Gigya.Microdot.ServiceDiscovery/Config/DiscoveryConfig.cs
+++ b/Gigya.Microdot.ServiceDiscovery/Config/DiscoveryConfig.cs
@@ -92,16 +92,16 @@ namespace Gigya.Microdot.ServiceDiscovery.Config
         public bool TryHttps { get; set; }
 
         /// <summary>
-        /// Controls the client certificate verification logic.
+        /// Controls the client verification logic for the server certificate.
         /// Default behavior is to validate that the server domain matches the certificate domain.
         /// </summary>
-        public ClientCertificateVerificationMode PerformClientCertificateVerification { get; set; } = ClientCertificateVerificationMode.VerifyDomain;
+        public ServerCertificateVerificationMode ServerCertificateVerification { get; set; } = ServerCertificateVerificationMode.VerifyDomain;
 
         /// <summary>
-        /// Controls the client certificate verification logic server side.
+        /// Controls the verification logic of the client certificate.
         /// Default behavior is that no verification is been made.
         /// </summary>
-        public ServerClientCertificateVerificationMode PerformServerClientCertificateVerification { get; set; } = ServerClientCertificateVerificationMode.Disable;
+        public ClientCertificateVerificationMode ClientCertificateVerification { get; set; } = ClientCertificateVerificationMode.Disable;
 
         /// <summary>
         /// The discovery mode to use, e.g. whether to use DNS resolving, Consul, etc.

--- a/Gigya.Microdot.ServiceDiscovery/Config/ServiceDiscoveryConfig.cs
+++ b/Gigya.Microdot.ServiceDiscovery/Config/ServiceDiscoveryConfig.cs
@@ -94,17 +94,17 @@ namespace Gigya.Microdot.ServiceDiscovery.Config
         /// </summary>
         public bool? TryHttps { get; set; }
 
-        /// /// <summary>
-        /// Controls the client certificate verification logic server side.
-        /// Defaults to null, will override the global settings for this service if set to anything but null.
-        /// </summary>
-        public ServerClientCertificateVerificationMode? PerformServerClientCertificateVerification { get; set; } = null;
-        
         /// <summary>
-        /// Controls the client certificate verification logic for a specific service.
+        /// Controls the client verification logic for the server certificate.
         /// Defaults to null, will override the global settings for this service if set to anything but null.
         /// </summary>
-        public ClientCertificateVerificationMode? PerformClientCertificateVerification { get; set; } = null;
+        public ServerCertificateVerificationMode? ServerCertificateVerification { get; set; } = null;
+
+        /// /// <summary>
+        /// Controls the verification logic of the client certificate.
+        /// Defaults to null, will override the global settings for this service if set to anything but null.
+        /// </summary>
+        public ClientCertificateVerificationMode? ClientCertificateVerification { get; set; } = null;
 
         /// <summary>
         /// Gets or sets the name of server certificate to trust. Defaults to null, which means it will trust a
@@ -139,8 +139,8 @@ namespace Gigya.Microdot.ServiceDiscovery.Config
                    DefaultPort == other.DefaultPort &&
                    DefaultSlotNumber == other.DefaultSlotNumber &&
                    UseHttpsOverride == other.UseHttpsOverride &&
-                   PerformServerClientCertificateVerification == other.PerformServerClientCertificateVerification &&
-                   PerformClientCertificateVerification == other.PerformClientCertificateVerification &&
+                   ClientCertificateVerification == other.ClientCertificateVerification &&
+                   ServerCertificateVerification == other.ServerCertificateVerification &&
                    string.Equals(SecurityRole, other.SecurityRole) &&
                    Equals(CachingPolicy, other.CachingPolicy) &&
                    SuppressHealthCheckAfterServiceUnused.Equals(other.SuppressHealthCheckAfterServiceUnused);
@@ -164,8 +164,8 @@ namespace Gigya.Microdot.ServiceDiscovery.Config
                 hashCode = (hashCode * 397) ^ (SecurityRole != null ? SecurityRole.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (CachingPolicy != null ? CachingPolicy.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ SuppressHealthCheckAfterServiceUnused.GetHashCode();
-                hashCode = (hashCode * 397) ^ PerformClientCertificateVerification.GetHashCode();
-                hashCode = (hashCode * 397) ^ PerformServerClientCertificateVerification.GetHashCode();
+                hashCode = (hashCode * 397) ^ ServerCertificateVerification.GetHashCode();
+                hashCode = (hashCode * 397) ^ ClientCertificateVerification.GetHashCode();
                 return hashCode;
             }
         }

--- a/Gigya.Microdot.ServiceProxy/HttpsAuthenticator.cs
+++ b/Gigya.Microdot.ServiceProxy/HttpsAuthenticator.cs
@@ -91,7 +91,8 @@ namespace Gigya.Microdot.ServiceProxy
                     if (hasSameRootCertificateHash == false)
                         Log.Error(_ => _("Server root certificate does not match client root certificate"));
 
-                    return hasSameRootCertificateHash;
+                    if (hasSameRootCertificateHash == false)
+                        return false;
                 }
 
                 if (configuration.SecurityRole != null)

--- a/Gigya.Microdot.ServiceProxy/ServiceProxyProvider.cs
+++ b/Gigya.Microdot.ServiceProxy/ServiceProxyProvider.cs
@@ -175,9 +175,11 @@ namespace Gigya.Microdot.ServiceProxy
             var forceHttps = serviceConfig.UseHttpsOverride ?? (ServiceInterfaceRequiresHttps || defaultConfig.UseHttpsOverride);
             var useHttps = tryHttps || forceHttps;
             string securityRole = serviceConfig.SecurityRole;
-            var verificationMode = serviceConfig.PerformClientCertificateVerification ??
-                                   defaultConfig.PerformClientCertificateVerification;
-            var httpKey = new HttpClientConfiguration(useHttps, securityRole, serviceConfig.RequestTimeout, verificationMode);
+            var verificationMode = serviceConfig.ServerCertificateVerification ??
+                                   defaultConfig.ServerCertificateVerification;
+            var supplyClientCertificate = (serviceConfig.ClientCertificateVerification ?? defaultConfig.ClientCertificateVerification)
+                                          == ClientCertificateVerificationMode.VerifyIdenticalRootCertificate;
+            var httpKey = new HttpClientConfiguration(useHttps, securityRole, serviceConfig.RequestTimeout, verificationMode, supplyClientCertificate);
 
             lock (HttpClientLock)
             {
@@ -198,7 +200,8 @@ namespace Gigya.Microdot.ServiceProxy
                         useHttps: false, 
                         securityRole: null, 
                         timeout:httpKey.Timeout, 
-                        verificationMode:httpKey.VerificationMode);
+                        verificationMode:httpKey.VerificationMode,
+                        supplyClientCertificate: httpKey.SupplyClientCertificate);
                 }
 
                 if (!(LastHttpClientKey?.Equals(httpKey) ?? false))
@@ -233,7 +236,8 @@ namespace Gigya.Microdot.ServiceProxy
                     useHttps:true,
                     configuration.SecurityRole,
                     configuration.Timeout,
-                    configuration.VerificationMode
+                    configuration.VerificationMode,
+                    configuration.SupplyClientCertificate
                     );
                 HttpMessageHandler messageHandler = null;
                 HttpClient httpsClient = null;
@@ -251,7 +255,8 @@ namespace Gigya.Microdot.ServiceProxy
                         useHttps: true, 
                         configuration.SecurityRole, 
                         configuration.Timeout,
-                        configuration.VerificationMode);
+                        configuration.VerificationMode,
+                        configuration.SupplyClientCertificate);
                     _httpMessageHandler = messageHandler;
                 }
             }

--- a/Gigya.Microdot.SharedLogic/HttpService/ClientCertificateVerificationModes.cs
+++ b/Gigya.Microdot.SharedLogic/HttpService/ClientCertificateVerificationModes.cs
@@ -11,13 +11,21 @@ namespace Gigya.Microdot.SharedLogic.HttpService
             bool useHttps,
             string securityRole,
             TimeSpan? timeout,
-            ClientCertificateVerificationMode verificationMode)
+            ServerCertificateVerificationMode verificationMode,
+            bool supplyClientCertificate)
         {
             UseHttps = useHttps;
             SecurityRole = securityRole;
             Timeout = timeout;
             VerificationMode = verificationMode;
+            SupplyClientCertificate = supplyClientCertificate;
         }
+
+        /// <summary>
+        /// Indicates whether or not the client should supply a certificate to the server
+        /// </summary>
+        public bool SupplyClientCertificate { get; set; }
+
         /// <summary>
         /// Controls whether an https client should be constructed or not
         /// </summary>
@@ -34,21 +42,21 @@ namespace Gigya.Microdot.SharedLogic.HttpService
         /// <summary>
         /// Controls which verification rules will be applied to the client certificate in case this is a secured connection
         /// </summary>
-        public ClientCertificateVerificationMode VerificationMode { get; }
+        public ServerCertificateVerificationMode VerificationMode { get; }
     }
 
     [Flags]
     [JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-    public enum ClientCertificateVerificationMode
+    public enum ServerCertificateVerificationMode
     {
         Disable = 0, //don't supply client certificate, ignore all errors
         VerifyDomain = 1, //verify certificate domain match
         VerifyIdenticalRootCertificate = 2//verify that the client and server certificate both have the same root 
     }
-
+    
     [Flags]
     [JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-    public enum ServerClientCertificateVerificationMode
+    public enum ClientCertificateVerificationMode
     {
         Disable = 0, // don't read client certificate hence no validation
         VerifyIdenticalRootCertificate = 1//verify that the client and server certificate both have the same root 


### PR DESCRIPTION
IF ClientCertificateVerificationMode.VerifyIdenticalRootCertificate is set the client will provide a client CertificateLocator
Did some naming refactoring