### PR TITLE
bug/#116879 removing ParallelScope.Fixtures from HttpServiceListenerT…

### DIFF
--- a/tests/Gigya.Microdot.UnitTests/ServiceListenerTests/HttpServiceListenerTests.cs
+++ b/tests/Gigya.Microdot.UnitTests/ServiceListenerTests/HttpServiceListenerTests.cs
@@ -43,7 +43,7 @@ using Gigya.Microdot.Hosting.Environment;
 namespace Gigya.Microdot.UnitTests.ServiceListenerTests
 {
 
-    [TestFixture, Parallelizable(ParallelScope.Fixtures)]
+    [TestFixture, Parallelizable(ParallelScope.None)]
     public class HttpServiceListenerTests
     {
         private IDemoService _insecureClient;


### PR DESCRIPTION
…ests as those tests seems to reuse private resources in an unsafe way